### PR TITLE
err msg for repset_add_table

### DIFF
--- a/cli/scripts/spock.py
+++ b/cli/scripts/spock.py
@@ -510,8 +510,7 @@ def get_table_list(table, db, pg_v):
 
   if len(ret) > 0:
     return(ret)
-
-  return([table])
+  util.exit_message(f"Could not find table that matches {table}",1)
 
 
 def repset_add_table(replication_set, table, db, synchronize_data=False, columns=None, row_filter=None, include_partitions=True, pg=None):


### PR DESCRIPTION
prevents error msg when adding table that does not exist to a repset:

Adding table t to replication set demo-replication-set.
WARNING: relation "t" does not exist
WARNING: LINE 1: ...e(set_name := 'demo-replication-set', relation := 't', synch...
WARNING: 