### PR TITLE
Fix patroni service file (patroni.service) which cause failure.

### DIFF
--- a/src/patroni/patroni.service
+++ b/src/patroni/patroni.service
@@ -1,15 +1,42 @@
 [Unit]
-Description=patroni HA Solution for PostgreSQL
-Documentation=https://patroni.readthedocs.io/en/latest/
-After=network.target
+Description=Runners to orchestrate a high-availability PostgreSQL
+After=syslog.target network.target
 
 [Service]
-User=etcd
-Type=notify
-ExecStart=/usr/local/patroni/patroni.py /etc/patroni.yaml
-Restart=always
-RestartSec=10s
-LimitNOFILE=40000
+Type=simple
+
+User=pgedge
+Group=pgedge
+
+# Read in configuration file if it exists, otherwise proceed
+EnvironmentFile=-/etc/patroni_env.conf
+
+# The default is the user's home directory, and if you want to change it, you must provide an absolute path.
+# WorkingDirectory=/home/sameuser
+
+# Where to send early-startup messages from the server
+# This is normally controlled by the global default set by systemd
+#StandardOutput=syslog
+
+# Pre-commands to start watchdog device
+# Uncomment if watchdog is part of your patroni setup
+#ExecStartPre=-/usr/bin/sudo /sbin/modprobe softdog
+#ExecStartPre=-/usr/bin/sudo /bin/chown postgres /dev/watchdog
+
+# Start the patroni process
+ExecStart=/usr/local/patroni/patroni.py /etc/patroni/patroni.yaml
+
+# Send HUP to reload from patroni.yml
+ExecReload=/bin/kill -s HUP $MAINPID
+
+# Only kill the patroni process, not it's children, so it will gracefully stop postgres
+KillMode=process
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=30
+
+# Restart the service if it crashed
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Patroni service was not starting due to configuration problems in the service file.