### PR TITLE
First batch of Test case adjustments to the various 8000 series test …

### DIFF
--- a/test/schedule_files/repset_env_noupdate
+++ b/test/schedule_files/repset_env_noupdate
@@ -17,7 +17,7 @@ t/8070_env_update_false_n1.pl
 t/8071_env_sub_n1n2_update_false.pl
 t/8072_env_update_false_n2.pl
 t/8073_env_sub_n2n1_update_false.pl
-t/8074_env_update_replication_check.pl8
+t/8074_env_update_replication_check.pl
 ##
 # cleanup scripts
 ##

--- a/test/t/8000_env_install_pgedge_node1.pl
+++ b/test/t/8000_env_install_pgedge_node1.pl
@@ -12,12 +12,14 @@ use lib './t/lib';
 use contains;
 use edge;
 
+my $n1dir="$ENV{EDGE_CLUSTER_DIR}/n1";
+my $homedir1="$n1dir/pgedge";
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 # First, we create a directory to hold node 1. 
 
-my $cmd = qq(mkdir -p $ENV{EDGE_N1});
+my $cmd = qq(mkdir -p $n1dir);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
@@ -27,7 +29,7 @@ print("full_buf = @$full_buf\n");
 
 # Download the install.py file into the directory
 
-my $cmd2 = qq(curl -fsSL $ENV{EDGE_REPO} > $ENV{EDGE_N1}/install.py);
+my $cmd2 = qq(curl -fsSL $ENV{EDGE_REPO} > $n1dir/install.py);
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 
@@ -38,9 +40,9 @@ print("success2 = $success2\n");
 
 # Move into the pgedge directory and run the install.py file.
 
-chdir("./$ENV{EDGE_CHDIR1}");
+chdir("./$n1dir");
 
-my $cmd3 = qq(python $ENV{EDGE_N1}/install.py);
+my $cmd3 = qq(python install.py);
 print("cmd3 = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 
@@ -48,10 +50,10 @@ my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cm
 #print("full_buf3 = @$full_buf3\n");
 print("stdout_buf3 = @$stdout_buf3\n");
 
-
+chdir("./../../../../");
 # Install PostgreSQL.
 
-my $cmd4 = qq($ENV{EDGE_N1}/pgedge/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_PORT1});
+my $cmd4 = qq($homedir1/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT});
 print("cmd4 = $cmd4\n");
 my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -60,25 +62,13 @@ print("full_buf4 = @$full_buf4\n");
 #print("stderr_buf4 = @$stderr_buf4\n");
 # In this case, stdout_buf4 contains content
 
-# Confirm that the node is installed properly - retrieve the path and port:
+print("The home directory is $homedir1\n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-#print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-
-print("The home directory is $ENV{EDGE_N1}\n");
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json2 = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-
-print("The port number is $ENV{EDGE_PORT1}\n");
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
 # Then, use the info to connect to psql and test for the existence of the extension.
 
-my $cmd5 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM pg_available_extensions WHERE name='spock'");
+my $cmd5 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM pg_available_extensions WHERE name='spock'");
 print("cmd5 = $cmd5\n");
 my($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 
@@ -90,7 +80,7 @@ print("stdout_buf5 = @$stdout_buf5\n");
 print("success5 = $success5\n");
 print("stdout_buf5 = @$stdout_buf5\n");
 print("full_buf5 = @$full_buf5\n");
-print("We just installed pgedge/spock in $ENV{EDGE_N1}.\n");
+print("We just installed pgedge/spock in $n1dir.\n");
 
 =head
 foreach (sort keys %ENV) {
@@ -100,7 +90,7 @@ foreach (sort keys %ENV) {
 }
 =cut
 
-if(contains(@$stdout_buf5[0], "3.2"))
+if(contains(@$stdout_buf5[0], "spock"))
 
 {
     exit(0);

--- a/test/t/8001_env_install_pgedge_node2.pl
+++ b/test/t/8001_env_install_pgedge_node2.pl
@@ -1,4 +1,4 @@
-# This test case will create the first of a two-node cluster.
+# This test case will create the second of a two-node cluster.
 # 
 
 use strict;
@@ -12,13 +12,15 @@ use lib './t/lib';
 use contains;
 use edge;
 
+my $n2dir="$ENV{EDGE_CLUSTER_DIR}/n2";
+my $homedir2="$n2dir/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# First, we create a directory to hold node 2. 
+# First, we create a directory to hold node 1. 
 
-
-
-my $cmd = qq(mkdir -p $ENV{EDGE_N2});
+my $cmd = qq(mkdir -p $n2dir);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
@@ -28,7 +30,7 @@ print("full_buf = @$full_buf\n");
 
 # Download the install.py file into the directory
 
-my $cmd2 = qq(curl -fsSL $ENV{EDGE_REPO} > $ENV{EDGE_N2}/install.py);
+my $cmd2 = qq(curl -fsSL $ENV{EDGE_REPO} > $n2dir/install.py);
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 
@@ -39,20 +41,20 @@ print("success2 = $success2\n");
 
 # Move into the pgedge directory and run the install.py file.
 
-chdir("./$ENV{EDGE_CHDIR2}");
+chdir("./$n2dir");
 
-my $cmd3 = qq(python $ENV{EDGE_N2}/install.py);
+my $cmd3 = qq(python install.py);
 print("cmd3 = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 
-print("success3 = $success3\n");
-print("full_buf3 = @$full_buf3\n");
-print("stderr_buf3 = @$stderr_buf3\n");
+#print("success3 = $success3\n");
+#print("full_buf3 = @$full_buf3\n");
+print("stdout_buf3 = @$stdout_buf3\n");
 
-
+chdir("./../../../../");
 # Install PostgreSQL.
 
-my $cmd4 = qq($ENV{EDGE_N2}/pgedge/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_PORT2});
+my $cmd4 = qq($homedir2/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2);
 print("cmd4 = $cmd4\n");
 my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -61,25 +63,13 @@ print("full_buf4 = @$full_buf4\n");
 #print("stderr_buf4 = @$stderr_buf4\n");
 # In this case, stdout_buf4 contains content
 
-# Confirm that the node is installed properly - retrieve the path and port:
+print("The home directory is $homedir2\n");
 
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-#print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-
-print("The home directory is {$ENV{EDGE_N2}}\n");
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json2 = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The port number is $myport2\n");
 
 # Then, use the info to connect to psql and test for the existence of the extension.
 
-my $cmd5 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM pg_available_extensions WHERE name='spock'");
+my $cmd5 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM pg_available_extensions WHERE name='spock'");
 print("cmd5 = $cmd5\n");
 my($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 
@@ -91,9 +81,17 @@ print("stdout_buf5 = @$stdout_buf5\n");
 print("success5 = $success5\n");
 print("stdout_buf5 = @$stdout_buf5\n");
 print("full_buf5 = @$full_buf5\n");
-print("We just installed pgedge/spock in $ENV{EDGE_N2}.\n");
+print("We just installed pgedge/spock in $n2dir.\n");
 
-if(contains(@$stdout_buf5[0], "3.2"))
+=head
+foreach (sort keys %ENV) {
+#    where ENV contains EDGE_ - look for selecting a regex from Env
+    next if $_ !~ "^EDGE_*";
+    print "$_  =  $ENV{$_}\n";
+}
+=cut
+
+if(contains(@$stdout_buf5[0], "spock"))
 
 {
     exit(0);
@@ -102,6 +100,3 @@ else
 {
     exit(1);
 }
-
-
-

--- a/test/t/8051_env_create_node1.pl
+++ b/test/t/8051_env_create_node1.pl
@@ -17,40 +17,28 @@ use edge;
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir1\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT1} = $out2->[0]->{"port"};
- print("The port number is $ENV{EDGE_PORT1}\n");
-
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
 #
 ## Check for n1 node existence
 
-my $json3 = `$ENV{EDGE_N1}/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
+my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
    #print("my json3 = $json3");
 my $out3 = decode_json($json3);
   $ENV{EDGE_NODE1_NAME} = $out3->[0]->{"node_name"};
    print("The node_name is = $ENV{EDGE_NODE1_NAME}\n");
-   
-   
+      
 if($ENV{EDGE_NODE1_NAME} eq "")
 
    {
    
-my $cmd2 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock node-create n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT1} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd2 = qq($homedir1/nodectl spock node-create n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 

--- a/test/t/8052_env_create_node2.pl
+++ b/test/t/8052_env_create_node2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll register node 1 and create the repset on that node.
+# In this case, we'll register node 2 and create the repset on that node.
 # After creating the repset, we'll query the spock.replication_set_table to see if the repset exists. 
 
 
@@ -17,30 +17,23 @@ use edge;
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+#add 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
 # We can retrieve the home directory from nodectl in json form... 
 
+print("The home directory is $homedir2\n"); 
 
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT2} = $out2->[0]->{"port"};
- print("The port number is $ENV{EDGE_PORT2}\n");
-
+print("The port number is $myport2\n");
 
 #
 ## Check for n2 node existence
 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
+my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
    #print("my json3 = $json3");
 my $out3 = decode_json($json3);
   $ENV{EDGE_NODE2_NAME} = $out3->[0]->{"node_name"};
@@ -51,7 +44,7 @@ if($ENV{EDGE_NODE2_NAME} eq "")
 
    {
    
-my $cmd2 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock node-create n2 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT2} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd2 = qq($homedir2/nodectl spock node-create n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 

--- a/test/t/8060_env_delete_false_n1.pl
+++ b/test/t/8060_env_delete_false_n1.pl
@@ -19,29 +19,15 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir1\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT1}\n");
-
-
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-create --replicate_delete=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/nodectl spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False );
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -51,6 +37,7 @@ print("\n");
 
 if(!(contains(@$stdout_buf5[0], "repset_create")))
 {
+    print("Unable to create repset, exiting with return code 1");
     exit(1);
 } 
 
@@ -60,14 +47,14 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT1}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_START_PORT}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
 
 
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
@@ -77,7 +64,7 @@ else
 # Creating public.$ENV{EDGE_TABLE} Table
 
   
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -94,7 +81,7 @@ else
   
      # Inserting into public.$ENV{EDGE_TABLE} table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -110,7 +97,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -120,7 +107,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N1}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -132,7 +119,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -147,7 +134,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -156,7 +143,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($ENV{EDGE_CLUSTER_DIR}/n1/pgedge/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8061_env_sub_n1n2_delete_false.pl
+++ b/test/t/8061_env_sub_n1n2_delete_false.pl
@@ -14,52 +14,30 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+#increment 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
+print("The home directory of node 1 is $homedir1\n");
 
-# We can retrieve the port number for node 1 from nodectl in json form...
+print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT2} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -68,13 +46,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N1} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n1 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n1n2"))
 

--- a/test/t/8062_env_delete_false_n2.pl
+++ b/test/t/8062_env_delete_false_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll register node 1 and create the repset on that node.
+# In this case, we'll register node 2 and create the repset on that node.
 # After creating the repset, we'll query the spock.replication_set_table to see if the repset exists. 
 
 
@@ -19,29 +19,18 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+#increment 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir2\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json1 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT2} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The port number is $myport2\n");
 
 
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-create --replicate_delete=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/nodectl spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False);
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -60,25 +49,22 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT2}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $myport2",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
 
-
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
-
- 
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -93,9 +79,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -111,7 +97,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -121,7 +107,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N2}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -133,7 +119,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -148,7 +134,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -157,7 +143,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8063_env_sub_n2n1_delete_false.pl
+++ b/test/t/8063_env_sub_n2n1_delete_false.pl
@@ -14,53 +14,27 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+#increment 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory of node 2 is $homedir2 \n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
+print("The port number of node 2 is $myport2\n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
+# Then, create the subscription on node 2:
 
 
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
-
-# Then, create the subscription on node 1:
-
-
-my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT1} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-add-repset sub_n2n1 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -69,13 +43,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N2} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n2 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n2n1"))
 

--- a/test/t/8064_env_delete_replication_check.pl
+++ b/test/t/8064_env_delete_replication_check.pl
@@ -23,40 +23,21 @@ no warnings 'uninitialized';
 
 
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+#add 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir1\n"); 
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
- $ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
+print("The home directory is $homedir2\n"); 
 
-my $json4 =`$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out4 = decode_json($json4);
- $ENV{EDGE_HOMEDIR2} = $out4->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
+print("The port number is {$ENV{EDGE_START_PORT}}\n");
 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT1}}\n");
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT2}}\n");
-
-
-
+print("The port number is {$myport2}\n");
 
 #====================================================================================================================================================
 # Checking Replication --delete=False
@@ -64,7 +45,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
     print("DELETE=FALSE REPLICATION CHECK\n");
     
     print ("-"x45,"\n");
-    my $cmd6= qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "DELETE FROM $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} where col1=2");
+    my $cmd6= qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "DELETE FROM public.foo where col1=2");
     print("cmd6 = $cmd6\n");
     my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
     
@@ -82,7 +63,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
      print ("-"x45,"\n");
       # Listing table contents of Port1 6432
       
-     my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+     my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -100,7 +81,7 @@ if(!(contains(@$stdout_buf9[0], "0 row")))
    print("DELETE=FALSE REPLICATION CHECK IN NODE n2\n");
    
     print ("-"x45,"\n");
-  my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} WHERE col1=2");
+  my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=2");
    print("cmd10 = $cmd10\n");
    my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
    print("stdout_buf10= @$stdout_buf10\n");
@@ -117,7 +98,7 @@ if(!(contains(@$stdout_buf10[0], "1 row")))
   #Checking Replication insert=True
     print("INSERT FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} values(888)");
+    my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo values(888)");
     print("cmd7 = $cmd7\n");
     my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
    
@@ -132,7 +113,7 @@ if(!(contains(@$stdout_buf7[0], "INSERT")))
       
      print("INSERT FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd8 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd8 = $cmd8\n");
    my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
    print("stdout_buf8= @$stdout_buf8\n");
@@ -147,7 +128,7 @@ if(!(contains(@$stdout_buf8[0], "888")))
   
     print("INSERT FUNCTION REPLICATION CHECK IN NODE n2 \n");
     print ("-"x45,"\n");
-  my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd11 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd11 = $cmd11\n");
    my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
    print("stdout_buf11= @$stdout_buf11\n");
@@ -164,7 +145,7 @@ if(!(contains(@$stdout_buf11[0], "888")))
    
     print("UPDATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd12 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "UPDATE $ENV{EDGE_TABLE} SET col1=333 where col1=3");
+    my $cmd12 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "UPDATE foo SET col1=333 where col1=3");
     print("cmd12 = $cmd12\n");
     my($success12, $error_message12, $full_buf12, $stdout_buf12, $stderr_buf12)= IPC::Cmd::run(command => $cmd12, verbose => 0);
    
@@ -179,7 +160,7 @@ exit(1);
       
      print("UPDATE FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd13 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd13 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd8 = $cmd8\n");
    my($success13, $error_message13, $full_buf13, $stdout_buf13, $stderr_buf13)= IPC::Cmd::run(command => $cmd13, verbose => 0);
    print("stdout_buf13= @$stdout_buf13\n");
@@ -193,7 +174,7 @@ if(!(contains(@$stdout_buf13[0], "333")))
   # Listing table contents of Port2 6433
    print("UPDATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd14 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd14 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd14 = $cmd14\n");
    my($success14, $error_message14, $full_buf14, $stdout_buf14, $stderr_buf14)= IPC::Cmd::run(command => $cmd14, verbose => 0);
    print("stdout_buf14= @$stdout_buf14\n");
@@ -209,7 +190,7 @@ if(!(contains(@$stdout_buf14[0], "333")))
     #Checking Replication Truncate=True
     print("TRUNCATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd15 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "TRUNCATE $ENV{EDGE_TABLE}");
+    my $cmd15 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "TRUNCATE foo");
     print("cmd15 = $cmd15\n");
     my($success15, $error_message15, $full_buf15, $stdout_buf15, $stderr_buf15)= IPC::Cmd::run(command => $cmd15, verbose => 0);
    
@@ -224,7 +205,7 @@ if(!(contains(@$stdout_buf15[0], "TRUNCATE")))
       
      print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n1\n"); 
       print ("-"x45,"\n"); 
-    my $cmd16 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd16 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd16 = $cmd16\n");
    my($success16, $error_message16, $full_buf16, $stdout_buf16, $stderr_buf16)= IPC::Cmd::run(command => $cmd16, verbose => 0);
    print("stdout_buf16= @$stdout_buf16\n");
@@ -238,7 +219,7 @@ if(!(contains(@$stdout_buf16[0], "0 rows")))
   # Listing table contents of Port2 6433
    print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd17 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd17 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd17 = $cmd17\n");
    my($success17, $error_message17, $full_buf17, $stdout_buf17, $stderr_buf17)= IPC::Cmd::run(command => $cmd17, verbose => 0);
    print("stdout_buf17= @$stdout_buf17\n");
@@ -255,7 +236,7 @@ if(!(contains(@$stdout_buf17[0], "0 rows")))
 
  print("GENERATING SERIES IN TABLE IN n1\n");
  
-   my $cmd18 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd18 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd18 = $cmd18\n");
    my($success18, $error_message18, $full_buf18, $stdout_buf18, $stderr_buf18)= IPC::Cmd::run(command => $cmd18, verbose => 0);
  
@@ -266,7 +247,7 @@ if(!(contains(@$stdout_buf18[0], "INSERT")))
 
    print("="x100,"\n");
    
-   my $cmd20 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+   my $cmd20 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd20 = $cmd20\n");
    my($success20, $error_message20, $full_buf20, $stdout_buf20, $stderr_buf20)= IPC::Cmd::run(command => $cmd20, verbose => 0);
    print("stdout_buf20= @$stdout_buf20\n");
@@ -280,7 +261,7 @@ if(!(contains(@$stdout_buf20[0], "10 rows")))
    #================================================================================================================================================================================
    
    
- my $cmd22 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+ my $cmd22 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd22 = $cmd22\n");
    my($success22, $error_message22, $full_buf22, $stdout_buf22, $stderr_buf22)= IPC::Cmd::run(command => $cmd22, verbose => 0);
    print("stdout_buf22= @$stdout_buf22\n");
@@ -295,7 +276,7 @@ if(!(contains(@$stdout_buf22[0], "10 rows")))
 
    print("GENERATING SERIES IN TABLE IN n2\n");
    
-   my $cmd19 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd19 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd19 = $cmd19\n");
    my($success19, $error_message19, $full_buf19, $stdout_buf19, $stderr_buf19)= IPC::Cmd::run(command => $cmd19, verbose => 0);
    #print("stdout_buf19= @$stdout_buf19\n");

--- a/test/t/8065_env_insert_false_n1.pl
+++ b/test/t/8065_env_insert_false_n1.pl
@@ -19,29 +19,15 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir1\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT1}\n");
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
 
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-create --replicate_insert=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/nodectl spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -60,25 +46,23 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT1}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_START_PORT}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
-
-
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
 
  
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -93,9 +77,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -111,7 +95,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -121,7 +105,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N1}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$homedir1/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -130,10 +114,10 @@ else
    
 #Adding Table to the Repset 
 
-if($ENV{EDEGE_SETNAME} eq ""){
+if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir1/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -148,7 +132,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -157,7 +141,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8066_env_sub_n1n2_insert_false.pl
+++ b/test/t/8066_env_sub_n1n2_insert_false.pl
@@ -14,52 +14,23 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory of node 1 is $homedir1\n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 1 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
+print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
 
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
-
-# Then, create the subscription on node 1:
-
-
-my $cmd11 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT2} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -68,13 +39,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N1} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n1 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n1n2"))
 

--- a/test/t/8067_env_insert_false_n2.pl
+++ b/test/t/8067_env_insert_false_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll register node 1 and create the repset on that node.
+# In this case, we'll register node 2 and create the repset on that node.
 # After creating the repset, we'll query the spock.replication_set_table to see if the repset exists. 
 
 
@@ -19,30 +19,16 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir2\n"); 
 
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
+print("The port number is $myport2\n");
 
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT2} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
-
-
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-create --replicate_insert=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -61,25 +47,25 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT2}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port=$myport2",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
 
 
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
 
  
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -94,9 +80,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -112,7 +98,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -122,7 +108,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N2}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -131,10 +117,10 @@ else
    
 #Adding Table to the Repset 
 
-if($ENV{EDEGE_SETNAME} eq ""){
+if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -149,7 +135,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -158,14 +144,12 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");
 
 # Test to confirm that cluster is set up.
-
-
 
 if(contains(@$stdout_buf10[0], "demo-repset"))
 

--- a/test/t/8068_env_sub_n2n1_insert_false.pl
+++ b/test/t/8068_env_sub_n2n1_insert_false.pl
@@ -15,52 +15,26 @@ use edge;
 
 # Our parameters are:
 
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
+print("The home directory of node 2 is $homedir2 \n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT1} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-add-repset sub_n2n1 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -69,13 +43,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N2} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR} and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n2n1"))
 

--- a/test/t/8069_env_insert_replication_check.pl
+++ b/test/t/8069_env_insert_replication_check.pl
@@ -25,35 +25,20 @@ no warnings 'uninitialized';
 # Our parameters are:
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir1\n"); 
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
- $ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-my $json4 =`$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out4 = decode_json($json4);
- $ENV{EDGE_HOMEDIR2} = $out4->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
+print("The home directory is $homedir2\n"); 
 
 
 # We can retrieve the port number from nodectl in json form...
 
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT1}}\n");
+print("The port number is {$ENV{EDGE_START_PORT}}\n");
 
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT2}}\n");
+print("The port number is {$myport2}\n");
 
 
 
@@ -64,7 +49,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
     print("INSERT=FALSE REPLICATION CHECK\n");
     
     print ("-"x45,"\n");
-    my $cmd6= qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} values(888)");
+    my $cmd6= qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO public.foo values(888)");
     print("cmd6 = $cmd6\n");
     my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
     
@@ -82,7 +67,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
      print ("-"x45,"\n");
       # Listing table contents of Port1 6432
       
-     my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+     my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -100,7 +85,7 @@ if(!(contains(@$stdout_buf9[0], "888")))
    print("DELETE=FALSE REPLICATION CHECK IN NODE n2\n");
    
     print ("-"x45,"\n");
-  my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} WHERE col1=888");
+  my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=888");
    print("cmd10 = $cmd10\n");
    my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
    print("stdout_buf10= @$stdout_buf10\n");
@@ -117,7 +102,7 @@ if(!(contains(@$stdout_buf10[0], "0 row")))
   #Checking Replication insert=True
     print("DELETE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "DELETE FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "DELETE FROM foo where col1=2");
     print("cmd7 = $cmd7\n");
     my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
    
@@ -132,7 +117,7 @@ if(!(contains(@$stdout_buf7[0], "DELETE")))
       
      print("INSERT FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd8 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd8 = $cmd8\n");
    my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
    print("stdout_buf8= @$stdout_buf8\n");
@@ -147,7 +132,7 @@ if(!(contains(@$stdout_buf8[0], "0 rows")))
   
     print("INSERT FUNCTION REPLICATION CHECK IN NODE n2 \n");
     print ("-"x45,"\n");
-  my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+  my $cmd11 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd11 = $cmd11\n");
    my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
    print("stdout_buf11= @$stdout_buf11\n");
@@ -164,7 +149,7 @@ if(!(contains(@$stdout_buf11[0], "0 rows")))
    
     print("UPDATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd12 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "UPDATE $ENV{EDGE_TABLE} SET col1=333 where col1=3");
+    my $cmd12 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "UPDATE foo SET col1=333 where col1=3");
     print("cmd12 = $cmd12\n");
     my($success12, $error_message12, $full_buf12, $stdout_buf12, $stderr_buf12)= IPC::Cmd::run(command => $cmd12, verbose => 0);
    
@@ -179,7 +164,7 @@ exit(1);
       
      print("UPDATE FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd13 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd13 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd8 = $cmd8\n");
    my($success13, $error_message13, $full_buf13, $stdout_buf13, $stderr_buf13)= IPC::Cmd::run(command => $cmd13, verbose => 0);
    print("stdout_buf13= @$stdout_buf13\n");
@@ -193,7 +178,7 @@ if(!(contains(@$stdout_buf13[0], "333")))
   # Listing table contents of Port2 6433
    print("UPDATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd14 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd14 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd14 = $cmd14\n");
    my($success14, $error_message14, $full_buf14, $stdout_buf14, $stderr_buf14)= IPC::Cmd::run(command => $cmd14, verbose => 0);
    print("stdout_buf14= @$stdout_buf14\n");
@@ -209,7 +194,7 @@ if(!(contains(@$stdout_buf14[0], "333")))
     #Checking Replication Truncate=True
     print("TRUNCATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd15 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "TRUNCATE $ENV{EDGE_TABLE}");
+    my $cmd15 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "TRUNCATE foo");
     print("cmd15 = $cmd15\n");
     my($success15, $error_message15, $full_buf15, $stdout_buf15, $stderr_buf15)= IPC::Cmd::run(command => $cmd15, verbose => 0);
    
@@ -224,7 +209,7 @@ if(!(contains(@$stdout_buf15[0], "TRUNCATE")))
       
      print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n1\n"); 
       print ("-"x45,"\n"); 
-    my $cmd16 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd16 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd16 = $cmd16\n");
    my($success16, $error_message16, $full_buf16, $stdout_buf16, $stderr_buf16)= IPC::Cmd::run(command => $cmd16, verbose => 0);
    print("stdout_buf16= @$stdout_buf16\n");
@@ -238,7 +223,7 @@ if(!(contains(@$stdout_buf16[0], "0 rows")))
   # Listing table contents of Port2 6433
    print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd17 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd17 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd17 = $cmd17\n");
    my($success17, $error_message17, $full_buf17, $stdout_buf17, $stderr_buf17)= IPC::Cmd::run(command => $cmd17, verbose => 0);
    print("stdout_buf17= @$stdout_buf17\n");
@@ -255,7 +240,7 @@ if(!(contains(@$stdout_buf17[0], "0 rows")))
 
  print("GENERATING SERIES IN TABLE IN n1\n");
  
-   my $cmd18 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd18 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd18 = $cmd18\n");
    my($success18, $error_message18, $full_buf18, $stdout_buf18, $stderr_buf18)= IPC::Cmd::run(command => $cmd18, verbose => 0);
  
@@ -266,7 +251,7 @@ if(!(contains(@$stdout_buf18[0], "INSERT")))
 
    print("="x100,"\n");
    
-   my $cmd20 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+   my $cmd20 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd20 = $cmd20\n");
    my($success20, $error_message20, $full_buf20, $stdout_buf20, $stderr_buf20)= IPC::Cmd::run(command => $cmd20, verbose => 0);
    print("stdout_buf20= @$stdout_buf20\n");
@@ -283,7 +268,7 @@ if(!(contains(@$stdout_buf20[0], "10 rows")))
 
    print("GENERATING SERIES IN TABLE IN n2\n");
    
-   my $cmd19 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd19 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd19 = $cmd19\n");
    my($success19, $error_message19, $full_buf19, $stdout_buf19, $stderr_buf19)= IPC::Cmd::run(command => $cmd19, verbose => 0);
    #print("stdout_buf19= @$stdout_buf19\n");
@@ -296,7 +281,7 @@ if(!(contains(@$stdout_buf20[0], "10 rows")))
 }
    print("="x100,"\n");
    
- my $cmd22 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+ my $cmd22 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd22 = $cmd22\n");
    my($success22, $error_message22, $full_buf22, $stdout_buf22, $stderr_buf22)= IPC::Cmd::run(command => $cmd22, verbose => 0);
    print("stdout_buf22= @$stdout_buf22\n");

--- a/test/t/8070_env_update_false_n1.pl
+++ b/test/t/8070_env_update_false_n1.pl
@@ -19,35 +19,20 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir1\n"); 
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT1}\n");
-
-
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-create --replicate_update=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/nodectl spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
 print("We just executed the command that creates the replication set (demo-repset)\n");
 print("\n");
-
 
 if(!(contains(@$stdout_buf5[0], "repset_create")))
 {
@@ -60,25 +45,23 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT1}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_START_PORT}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
-
-
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
 
  
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -93,9 +76,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -111,7 +94,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -121,7 +104,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N1}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$homedir1/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -130,10 +113,10 @@ else
    
 #Adding Table to the Repset 
 
-if($ENV{EDEGE_SETNAME} eq ""){
+if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir1/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -148,7 +131,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -157,7 +140,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8071_env_sub_n1n2_update_false.pl
+++ b/test/t/8071_env_sub_n1n2_update_false.pl
@@ -14,52 +14,24 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory of node 1 is $homedir1\n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 1 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
 # Then, create the subscription on node 1:
 
-
-my $cmd11 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT2} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -68,13 +40,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N1} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n1 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n1n2"))
 

--- a/test/t/8072_env_update_false_n2.pl
+++ b/test/t/8072_env_update_false_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll register node 1 and create the repset on that node.
+# In this case, we'll register node 2 and create the repset on that node.
 # After creating the repset, we'll query the spock.replication_set_table to see if the repset exists. 
 
 
@@ -19,30 +19,16 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir2\n"); 
 
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
+print("The port number is $myport2\n");
 
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT2} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
-
-
-
-my $cmd5 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-create --replicate_update=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -61,25 +47,25 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT2}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port=$myport2",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
 
 
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
 
  
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -94,9 +80,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -112,7 +98,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -122,7 +108,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N2}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$homedir2/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -131,10 +117,10 @@ else
    
 #Adding Table to the Repset 
 
-if($ENV{EDEGE_SETNAME} eq ""){
+if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -149,7 +135,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -158,7 +144,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8073_env_sub_n2n1_update_false.pl
+++ b/test/t/8073_env_sub_n2n1_update_false.pl
@@ -14,53 +14,25 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
+print("The home directory of node 2 is $homedir2 \n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
-
-my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT1} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-add-repset sub_n2n1 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -69,13 +41,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N2} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n2 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n2n1"))
 

--- a/test/t/8074_env_update_replication_check.pl
+++ b/test/t/8074_env_update_replication_check.pl
@@ -24,36 +24,18 @@ no warnings 'uninitialized';
 
 # Our parameters are:
 
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir1\n"); 
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
- $ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
+print("The home directory is $homedir2\n"); 
 
-my $json4 =`$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out4 = decode_json($json4);
- $ENV{EDGE_HOMEDIR2} = $out4->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
+print("The port number is {$ENV{EDGE_START_PORT}}\n");
 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT1}}\n");
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT2}}\n");
+print("The port number is {$myport2}\n");
 
 
 
@@ -61,7 +43,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
    
     print("UPDATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd12 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "UPDATE $ENV{EDGE_TABLE} SET col1=333 where col1=3");
+    my $cmd12 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "UPDATE foo SET col1=333 where col1=3");
     print("cmd12 = $cmd12\n");
     my($success12, $error_message12, $full_buf12, $stdout_buf12, $stderr_buf12)= IPC::Cmd::run(command => $cmd12, verbose => 0);
    
@@ -76,7 +58,7 @@ exit(1);
       
      print("UPDATE FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd13 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd13 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd13 = $cmd13\n");
    my($success13, $error_message13, $full_buf13, $stdout_buf13, $stderr_buf13)= IPC::Cmd::run(command => $cmd13, verbose => 0);
    print("stdout_buf13= @$stdout_buf13\n");
@@ -90,7 +72,7 @@ if(!(contains(@$stdout_buf13[0], "333")))
   # Listing table contents of Port2 6433
    print("UPDATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd14 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=333");
+  my $cmd14 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=333");
    print("cmd14 = $cmd14\n");
    my($success14, $error_message14, $full_buf14, $stdout_buf14, $stderr_buf14)= IPC::Cmd::run(command => $cmd14, verbose => 0);
    print("stdout_buf14= @$stdout_buf14\n");
@@ -110,7 +92,7 @@ if(!(contains(@$stdout_buf14[0], "0 rows")))
     print("INSERT=TRUE REPLICATION CHECK\n");
     
     print ("-"x45,"\n");
-    my $cmd6= qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} values(888)");
+    my $cmd6= qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO public.foo values(888)");
     print("cmd6 = $cmd6\n");
     my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
     
@@ -128,7 +110,7 @@ if(!(contains(@$stdout_buf14[0], "0 rows")))
      print ("-"x45,"\n");
       # Listing table contents of Port1 6432
       
-     my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+     my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -146,7 +128,7 @@ if(!(contains(@$stdout_buf9[0], "888")))
    print("INSERT=TRUE REPLICATION CHECK IN NODE n2\n");
    
     print ("-"x45,"\n");
-  my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} WHERE col1=888");
+  my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=888");
    print("cmd10 = $cmd10\n");
    my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
    print("stdout_buf10= @$stdout_buf10\n");
@@ -163,7 +145,7 @@ if(!(contains(@$stdout_buf10[0], "1 row")))
   #Checking Replication delete=True
     print("DELETE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "DELETE FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "DELETE FROM foo where col1=2");
     print("cmd7 = $cmd7\n");
     my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
    
@@ -178,7 +160,7 @@ if(!(contains(@$stdout_buf7[0], "DELETE")))
       
      print("INSERT FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd8 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd8 = $cmd8\n");
    my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
    print("stdout_buf8= @$stdout_buf8\n");
@@ -193,7 +175,7 @@ if(!(contains(@$stdout_buf8[0], "0 rows")))
   
     print("INSERT FUNCTION REPLICATION CHECK IN NODE n2 \n");
     print ("-"x45,"\n");
-  my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+  my $cmd11 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd11 = $cmd11\n");
    my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
    print("stdout_buf11= @$stdout_buf11\n");
@@ -211,7 +193,7 @@ if(!(contains(@$stdout_buf11[0], "0 rows")))
     #Checking Replication Truncate=True
     print("TRUNCATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd15 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "TRUNCATE $ENV{EDGE_TABLE}");
+    my $cmd15 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "TRUNCATE foo");
     print("cmd15 = $cmd15\n");
     my($success15, $error_message15, $full_buf15, $stdout_buf15, $stderr_buf15)= IPC::Cmd::run(command => $cmd15, verbose => 0);
    
@@ -226,7 +208,7 @@ if(!(contains(@$stdout_buf15[0], "TRUNCATE")))
       
      print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n1\n"); 
       print ("-"x45,"\n"); 
-    my $cmd16 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd16 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd16 = $cmd16\n");
    my($success16, $error_message16, $full_buf16, $stdout_buf16, $stderr_buf16)= IPC::Cmd::run(command => $cmd16, verbose => 0);
    print("stdout_buf16= @$stdout_buf16\n");
@@ -240,7 +222,7 @@ if(!(contains(@$stdout_buf16[0], "0 rows")))
   # Listing table contents of Port2 6433
    print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd17 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd17 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd17 = $cmd17\n");
    my($success17, $error_message17, $full_buf17, $stdout_buf17, $stderr_buf17)= IPC::Cmd::run(command => $cmd17, verbose => 0);
    print("stdout_buf17= @$stdout_buf17\n");
@@ -257,7 +239,7 @@ if(!(contains(@$stdout_buf17[0], "0 rows")))
 
  print("GENERATING SERIES IN TABLE IN n1\n");
  
-   my $cmd18 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd18 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd18 = $cmd18\n");
    my($success18, $error_message18, $full_buf18, $stdout_buf18, $stderr_buf18)= IPC::Cmd::run(command => $cmd18, verbose => 0);
  
@@ -268,7 +250,7 @@ if(!(contains(@$stdout_buf18[0], "INSERT")))
 
    print("="x100,"\n");
    
-   my $cmd20 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+   my $cmd20 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd20 = $cmd20\n");
    my($success20, $error_message20, $full_buf20, $stdout_buf20, $stderr_buf20)= IPC::Cmd::run(command => $cmd20, verbose => 0);
    print("stdout_buf20= @$stdout_buf20\n");
@@ -283,7 +265,7 @@ if(!(contains(@$stdout_buf20[0], "10 rows")))
 
    print("="x100,"\n");
 
- my $cmd22 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+ my $cmd22 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd22 = $cmd22\n");
    my($success22, $error_message22, $full_buf22, $stdout_buf22, $stderr_buf22)= IPC::Cmd::run(command => $cmd22, verbose => 0);
    print("stdout_buf22= @$stdout_buf22\n");
@@ -299,7 +281,7 @@ if(!(contains(@$stdout_buf22[0], "10 rows")))
 
    print("GENERATING SERIES IN TABLE IN n2\n");
    
-   my $cmd19 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd19 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd19 = $cmd19\n");
    my($success19, $error_message19, $full_buf19, $stdout_buf19, $stderr_buf19)= IPC::Cmd::run(command => $cmd19, verbose => 0);
    #print("stdout_buf19= @$stdout_buf19\n");

--- a/test/t/8076_env_sub_n1n2_truncate_false.pl
+++ b/test/t/8076_env_sub_n1n2_truncate_false.pl
@@ -14,52 +14,26 @@ use contains;
 use edge;
 
 # Our parameters are:
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory of node 1 is $homedir1\n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 1 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT2} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -68,13 +42,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N1} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n1 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n1n2"))
 

--- a/test/t/8077_env_truncate_false_n2.pl
+++ b/test/t/8077_env_truncate_false_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll register node 1 and create the repset on that node.
+# In this case, we'll register node 2 and create the repset on that node.
 # After creating the repset, we'll query the spock.replication_set_table to see if the repset exists. 
 
 
@@ -19,30 +19,17 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir2\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
-$ENV{EDGE_PORT2} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The port number is $myport2\n");
 
 
 
-my $cmd5 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-create --replicate_truncate=False $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_truncate=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -61,25 +48,25 @@ print("="x100,"\n");
 
 ##Table validation
 
-my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port= $ENV{EDGE_PORT2}",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{EDGE_DB};host=$ENV{EDGE_HOST};port=$myport2",$ENV{EDGE_USERNAME},$ENV{EDGE_PASSWORD});
 
 
 
-my $table_exists = $dbh->table_info(undef, 'public', $ENV{EDGE_TABLE}, 'TABLE')->fetch;
+my $table_exists = $dbh->table_info(undef, 'public', 'foo', 'TABLE')->fetch;
 
 if ($table_exists) {
-    print "Table '$ENV{EDGE_TABLE}' already exists in the database.\n";
+    print "Table 'foo' already exists in the database.\n";
     
     print("\n");
 } 
 
 else
 {
-# Creating public.$ENV{EDGE_TABLE} Table
+# Creating public.foo Table
 
 
  
-    my $cmd6 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "CREATE TABLE $ENV{EDGE_TABLE} (col1 INT PRIMARY KEY)");
+    my $cmd6 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "CREATE TABLE foo (col1 INT PRIMARY KEY)");
     
     print("cmd6 = $cmd6\n");
     
@@ -94,9 +81,9 @@ else
    print ("-"x100,"\n"); 
    
   
-     # Inserting into public.$ENV{EDGE_TABLE} table
+     # Inserting into public.foo table
 
-   my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
 
    print("cmd7 = $cmd7\n");
    my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
@@ -112,7 +99,7 @@ else
     
   #checking repset
   
-  my $cmd9 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='$ENV{EDGE_REPSET}'");
+  my $cmd9 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set where set_name='demo-repset'");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -122,7 +109,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_N2}/pgedge/nc spock repset-list-tables $ENV{EDGE_SCHEMA} $ENV{EDGE_DB}`;
+    my $json3 = `$homedir2/nc spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -134,7 +121,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-add-table $ENV{EDGE_REPSET} $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
@@ -149,7 +136,7 @@ if($ENV{EDEGE_SETNAME} eq ""){
 
 
 else {
-   print ("Table $ENV{EDGE_TABLE} is already added to $ENV{EDGE_REPSET}\n");
+   print ("Table foo is already added to demo-repset\n");
     
    
 }
@@ -158,7 +145,7 @@ print("="x100,"\n");
 
 # Then, use the info to connect to psql and test for the existence of the replication set.
 
-my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
+my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.replication_set");
 print("cmd10 = $cmd10\n");
 my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
 #print("stdout_buf10 = @$stdout_buf10\n");

--- a/test/t/8078_env_sub_n2n1_truncate_false.pl
+++ b/test/t/8078_env_sub_n2n1_truncate_false.pl
@@ -14,53 +14,24 @@ use contains;
 use edge;
 
 # Our parameters are:
-
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory of node 2 is $homedir2 \n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is $ENV{EDGE_HOMEDIR1}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is $ENV{EDGE_PORT1}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is $ENV{EDGE_HOMEDIR2} \n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is $ENV{EDGE_PORT2}\n");
+print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
-
-my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_PORT1} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-add-repset sub_n2n1 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 
@@ -69,13 +40,13 @@ print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 
 # Then, confirm that the subscription exists.
 
-print("We just created the subscription on $ENV{EDGE_N2} and are now verifying it exists.\n");
+print("We just created the subscription on $ENV{EDGE_CLUSTER_DIR}/n2 and are now verifying it exists.\n");
 
 if(contains(@$stdout_buf7[0], "sub_n2n1"))
 

--- a/test/t/8079_env_truncate_replication_check.pl
+++ b/test/t/8079_env_truncate_replication_check.pl
@@ -23,37 +23,19 @@ no warnings 'uninitialized';
 
 
 # Our parameters are:
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The n1 home directory is $homedir1\n"); 
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
- $ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
+print("The n2 home directory is $homedir2\n"); 
 
-my $json4 =`$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out4 = decode_json($json4);
- $ENV{EDGE_HOMEDIR2} = $out4->[0]->{"home"};
-#print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
+print("The n1 port number is {$ENV{EDGE_START_PORT}}\n");
 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT1}}\n");
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-print("The port number is {$ENV{EDGE_PORT2}}\n");
+print("The n2 port number is {$myport2}\n");
 
 
 
@@ -64,7 +46,7 @@ print("The port number is {$ENV{EDGE_PORT2}}\n");
   
     print("TRUNCATE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd15 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "TRUNCATE $ENV{EDGE_TABLE}");
+    my $cmd15 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "TRUNCATE foo");
     print("cmd15 = $cmd15\n");
     my($success15, $error_message15, $full_buf15, $stdout_buf15, $stderr_buf15)= IPC::Cmd::run(command => $cmd15, verbose => 0);
    
@@ -79,7 +61,7 @@ if(!(contains(@$stdout_buf15[0], "TRUNCATE")))
       
      print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n1\n"); 
       print ("-"x45,"\n"); 
-    my $cmd16 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+    my $cmd16 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd16 = $cmd16\n");
    my($success16, $error_message16, $full_buf16, $stdout_buf16, $stderr_buf16)= IPC::Cmd::run(command => $cmd16, verbose => 0);
    print("stdout_buf16= @$stdout_buf16\n");
@@ -94,7 +76,7 @@ if(!(contains(@$stdout_buf16[0], "0 rows")))
   
    print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
-  my $cmd17 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+  my $cmd17 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd17 = $cmd17\n");
    my($success17, $error_message17, $full_buf17, $stdout_buf17, $stderr_buf17)= IPC::Cmd::run(command => $cmd17, verbose => 0);
    print("stdout_buf17= @$stdout_buf17\n");
@@ -111,7 +93,7 @@ if(!(contains(@$stdout_buf17[0], "10 rows")))
 
  print("GENERATING SERIES IN TABLE IN n1\n");
  
-   my $cmd18 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_TABLE} select generate_series(1,10)");
+   my $cmd18 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO foo select generate_series(1,10)");
    print("cmd18 = $cmd18\n");
    my($success18, $error_message18, $full_buf18, $stdout_buf18, $stderr_buf18)= IPC::Cmd::run(command => $cmd18, verbose => 0);
  
@@ -122,7 +104,7 @@ if(!(contains(@$stdout_buf18[0], "INSERT")))
 
    print("="x100,"\n");
    
-   my $cmd20 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+   my $cmd20 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd20 = $cmd20\n");
    my($success20, $error_message20, $full_buf20, $stdout_buf20, $stderr_buf20)= IPC::Cmd::run(command => $cmd20, verbose => 0);
    print("stdout_buf20= @$stdout_buf20\n");
@@ -135,7 +117,7 @@ if(!(contains(@$stdout_buf20[0], "10 rows")))
   
     print("="x100,"\n");
 
- my $cmd22 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+ my $cmd22 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd22 = $cmd22\n");
    my($success22, $error_message22, $full_buf22, $stdout_buf22, $stderr_buf22)= IPC::Cmd::run(command => $cmd22, verbose => 0);
    print("stdout_buf22= @$stdout_buf22\n");
@@ -152,7 +134,7 @@ if(!(contains(@$stdout_buf22[0], "10 rows")))
     print("INSERT=TRUE REPLICATION CHECK\n");
     
     print ("-"x45,"\n");
-    my $cmd6= qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "INSERT INTO $ENV{EDGE_SCHEMA}.$ENV{EDGE_TABLE} values(888)");
+    my $cmd6= qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "INSERT INTO public.foo values(888)");
     print("cmd6 = $cmd6\n");
     my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
     
@@ -170,7 +152,7 @@ if(!(contains(@$stdout_buf22[0], "10 rows")))
      print ("-"x45,"\n");
       # Listing table contents of Port1 6432
       
-     my $cmd9 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE}");
+     my $cmd9 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo");
    print("cmd9 = $cmd9\n");
    my($success9, $error_message9, $full_buf9, $stdout_buf9, $stderr_buf9)= IPC::Cmd::run(command => $cmd9, verbose => 0);
    print("stdout_buf9= @$stdout_buf9\n");
@@ -188,7 +170,7 @@ if(!(contains(@$stdout_buf9[0], "888")))
    print("INSERT=TRUE REPLICATION CHECK IN NODE n2\n");
    
     print ("-"x45,"\n");
-  my $cmd10 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} WHERE col1=888");
+  my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=888");
    print("cmd10 = $cmd10\n");
    my($success10, $error_message10, $full_buf10, $stdout_buf10, $stderr_buf10)= IPC::Cmd::run(command => $cmd10, verbose => 0);
    print("stdout_buf10= @$stdout_buf10\n");
@@ -206,7 +188,7 @@ if(!(contains(@$stdout_buf10[0], "1 row")))
   
     print("DELETE FUNCTION REPLICATION CHECK\n");
      print ("-"x45,"\n");
-    my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "DELETE FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "DELETE FROM foo where col1=2");
     print("cmd7 = $cmd7\n");
     my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
    
@@ -221,7 +203,7 @@ if(!(contains(@$stdout_buf7[0], "DELETE")))
       
      print("DELETE FUNCTION REPLICATION CHECK IN NODE n1 \n");
       print ("-"x45,"\n"); 
-    my $cmd8 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+    my $cmd8 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd8 = $cmd8\n");
    my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);
    print("stdout_buf8= @$stdout_buf8\n");
@@ -236,7 +218,7 @@ if(!(contains(@$stdout_buf8[0], "0 rows")))
   
     print("DELETE FUNCTION REPLICATION CHECK IN NODE n2 \n");
     print ("-"x45,"\n");
-  my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql  -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM $ENV{EDGE_TABLE} where col1=2");
+  my $cmd11 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo where col1=2");
    print("cmd11 = $cmd11\n");
    my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
    print("stdout_buf11= @$stdout_buf11\n");

--- a/test/t/8081_env_repset_drop_n2.pl
+++ b/test/t/8081_env_repset_drop_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll drop the repset on node1.
+# In this case, we'll drop the repset on node2.
  
 
 
@@ -17,30 +17,18 @@ use edge;
 no warnings 'uninitialized';
 
 # Our parameters are:
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+#increment 1 to the default port for use with node n2
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory from nodectl in json form... 
+print("The home directory is $homedir2\n"); 
 
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-#print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The port number is $myport2\n");
 
 
-
-my $cmd3 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock repset-drop $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+my $cmd3 = qq($homedir2/nodectl spock repset-drop demo-repset $ENV{EDGE_DB});
 print("cmd3 = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 

--- a/test/t/8082_env_sub_drop_n1.pl
+++ b/test/t/8082_env_sub_drop_n1.pl
@@ -13,53 +13,25 @@ use lib './t/lib';
 use contains;
 use edge;
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
+print("The home directory of node 1 is {$homedir1}\n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is {$ENV{EDGE_HOMEDIR1}}\n");
-
-# We can retrieve the port number for node 1 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info pg17`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is {$ENV{EDGE_PORT1}}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is {$ENV{EDGE_HOMEDIR2}}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info pg17`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is {$ENV{EDGE_PORT2}}\n");
+print("The port number on node 1 is {$ENV{EDGE_START_PORT}}\n");
 
 # Then, drop the subscription on node 1:
 
-my $cmd11 = qq($ENV{EDGE_HOMEDIR1}/nodectl spock sub-drop sub_n1n2 $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/nodectl spock sub-drop sub_n1n2 $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 #print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 #print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 

--- a/test/t/8083_env_sub_drop_n2.pl
+++ b/test/t/8083_env_sub_drop_n2.pl
@@ -13,53 +13,25 @@ use lib './t/lib';
 use contains;
 use edge;
 # Our parameters are:
-
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory for node 1 from nodectl in json form... 
+print("The home directory of node 2 is {$homedir2}\n");
 
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory of node 1 is {$ENV{EDGE_HOMEDIR1}}\n");
-
-# We can retrieve the port number for node 1 from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N1}/pgedge/nc --json info pg17`;
-# print("my json = $json2");
-my $out2 = decode_json($json2);
-$ENV{EDGE_PORT1} = $out2->[0]->{"port"};
-print("The port number on node 1 is {$ENV{EDGE_PORT1}}\n");
-
-
-# We can retrieve the home directory for node 2 from nodectl in json form... 
-
-my $json3 = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json3");
-my $out3 = decode_json($json3);
-$ENV{EDGE_HOMEDIR2} = $out3->[0]->{"home"};
-print("The home directory of node 2 is {$ENV{EDGE_HOMEDIR2}}\n");
-
-# We can retrieve the port number for node 2 from nodectl in json form...
-
-my $json4 = `$ENV{EDGE_N2}/pgedge/nc --json info pg17`;
-# print("my json = $json4");
-my $out4 = decode_json($json4);
-$ENV{EDGE_PORT2} = $out4->[0]->{"port"};
-print("The port number of node 2 is {$ENV{EDGE_PORT2}}\n");
+print("The port number of node 2 is {$myport2}\n");
 
 # Then, drop the subscription on node 1:
 
-my $cmd11 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock sub-drop sub_n2n1 $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/nodectl spock sub-drop sub_n2n1 $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 #print("stdout_buf11 = @$stdout_buf11\n");
 
 # Then, we connect with psql and confirm that the subscription exists.
 
-my $cmd7 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
+my $cmd7 = qq($homedir2/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.subscription");
 #print("cmd7 = $cmd7\n");
 my($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 

--- a/test/t/8084_env_table_drop_n1.pl
+++ b/test/t/8084_env_table_drop_n1.pl
@@ -16,35 +16,23 @@ use contains;
 use edge;
 use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
-
+ 
 # Our parameters are:
-
+#pgedge home directory for n1
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir1\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N1}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR1} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR1}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N1}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT1} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT1}\n");
+print("The port number is $ENV{EDGE_START_PORT}\n");
 
 
      print ("-"x150,"\n");
 
      # Dropping public.foo Table
 
-     my $cmd6 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "DROP TABLE $ENV{EDGE_TABLE} CASCADE");
+     my $cmd6 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "DROP TABLE public.foo CASCADE");
      print("cmd6 = $cmd6\n");
      my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
      #print("full6 = @$full_buf6\n");
@@ -54,7 +42,7 @@ print("The port number is $ENV{EDGE_PORT1}\n");
       print("stdout_buf6 = @$stdout_buf6\n");
     
 
-     my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT1} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.tables");
+     my $cmd7 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_START_PORT} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.tables");
      #print("cmd7 = $cmd7\n");
      my ($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 

--- a/test/t/8085_env_table_drop_n2.pl
+++ b/test/t/8085_env_table_drop_n2.pl
@@ -18,33 +18,21 @@ use List::MoreUtils qw(pairwise);
 no warnings 'uninitialized';
 
 # Our parameters are:
-
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
+print("The home directory is $homedir2\n"); 
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-# print("my json = $json");
-my $out = decode_json($json);
-$ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json1 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-# print("my json = $json1");
-my $out1 = decode_json($json1);
- $ENV{EDGE_PORT2} = $out1->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The port number is $myport2\n");
 
 
      print ("-"x150,"\n");
 
      # Dropping public.foo Table
 
-     my $cmd6 = qq($ENV{EDGE_HOMEDIR2}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "DROP TABLE $ENV{EDGE_TABLE} CASCADE");
+     my $cmd6 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "DROP TABLE public.foo CASCADE");
      print("cmd6 = $cmd6\n");
      my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
      #print("full6 = @$full_buf6\n");
@@ -54,7 +42,7 @@ print("The port number is $ENV{EDGE_PORT2}\n");
       print("stdout_buf6 = @$stdout_buf6\n");
     
 
-     my $cmd7 = qq($ENV{EDGE_HOMEDIR1}/$ENV{EDGE_VERSION}/bin/psql -t -h $ENV{EDGE_HOST} -p $ENV{EDGE_PORT2} -d $ENV{EDGE_DB} -c "SELECT * FROM spock.tables");
+     my $cmd7 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM spock.tables");
      #print("cmd7 = $cmd7\n");
      my ($success7, $error_message7, $full_buf7, $stdout_buf7, $stderr_buf7)= IPC::Cmd::run(command => $cmd7, verbose => 0);
 

--- a/test/t/8086_env_node_drop_n1.pl
+++ b/test/t/8086_env_node_drop_n1.pl
@@ -1,10 +1,10 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll drop the repset on node1.
- 
+# In this case, we'll drop the node 1.
 
- 
+
+
 use strict;
 use warnings;
 use File::Which;
@@ -14,8 +14,6 @@ use JSON;
 use lib './t/lib';
 use contains;
 use edge;
-no warnings 'uninitialized';
-
 # Our parameters are:
 #pgedge home directory for n1
 my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
@@ -23,17 +21,16 @@ print("whoami = $ENV{EDGE_REPUSER}\n");
 
 print("The home directory is $homedir1\n"); 
 
-print("The port number is $ENV{EDGE_START_PORT}\n");
+# Drop n1 node
 
-my $cmd3 = qq($homedir1/nodectl spock repset-drop demo-repset $ENV{EDGE_DB});
-print("cmd3 = $cmd3\n");
-my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
+my $cmd2 = qq($homedir1/nodectl spock node-drop n1 $ENV{EDGE_DB});
+print("cmd2 = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout_buf2 = @$stdout_buf2\n");
 
-print("success3 = $success3\n");
-#print("stdout_buf3 = @$stdout_buf3\n");
 
-  
- if(contains(@$stdout_buf3[0], "repset_drop"))
+
+if(contains(@$stdout_buf2[0], "node_drop"))
 
 {
     exit(0);
@@ -42,14 +39,4 @@ else
 {
     exit(1);
 }
-
-
-
-
-
-
-
-
-
-
 

--- a/test/t/8087_env_node_drop_n2.pl
+++ b/test/t/8087_env_node_drop_n2.pl
@@ -1,7 +1,7 @@
 # This is part of a complex test case; after creating a two node cluster on the localhost, 
 # the test case executes the commands in the Getting Started Guide at the pgEdge website.
 #
-# In this case, we'll drop the node 1.
+# In this case, we'll drop the node 2.
 
 
 
@@ -15,28 +15,15 @@ use lib './t/lib';
 use contains;
 use edge;
 # Our parameters are:
-
+#pgedge home directory for n2
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
-# We can retrieve the home directory from nodectl in json form... 
-
-my $json = `$ENV{EDGE_N2}/pgedge/nc --json info`;
-#print("my json = $json");
-my $out = decode_json($json);
- $ENV{EDGE_HOMEDIR2} = $out->[0]->{"home"};
-print("The home directory is $ENV{EDGE_HOMEDIR2}\n"); 
-
-# We can retrieve the port number from nodectl in json form...
-
-my $json2 = `$ENV{EDGE_N2}/pgedge/nc --json info $ENV{EDGE_VERSION}`;
-#print("my json = $json2");
-my $out2 = decode_json($json2);
- $ENV{EDGE_PORT2} = $out2->[0]->{"port"};
-print("The port number is $ENV{EDGE_PORT2}\n");
+print("The home directory is $homedir2\n"); 
 
 # Drop n2 node
 
-my $cmd2 = qq($ENV{EDGE_HOMEDIR2}/nodectl spock node-drop n2 $ENV{EDGE_DB});
+my $cmd2 = qq($homedir2/nodectl spock node-drop n2 $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 #print("stdout_buf2 = @$stdout_buf2\n");

--- a/test/t/8998_env_remove_pgedge.pl
+++ b/test/t/8998_env_remove_pgedge.pl
@@ -32,9 +32,9 @@ my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cm
 print("I'm removing the .pgpass file with the following command: = $cmd4\n");
 print("stdout_buf = @$stdout_buf4\n");
 print ("The pgpass file should be gone now.\n");
-print ("We're checking to see if the $ENV{EDGE_N1} directory still exists.\n");
+print ("We're checking to see if the $ENV{EDGE_CLUSTER_DIR} directory still exists.\n");
 
-if(defined($ENV{EDGE_N1}) && length($ENV{EDGE_N1}) > 0)
+if(defined($ENV{EDGE_CLUSTER_DIR}) && length($ENV{EDGE_CLUSTER_DIR}) > 0)
 {
     exit(0);
 }

--- a/test/t/lib/config.env
+++ b/test/t/lib/config.env
@@ -12,54 +12,15 @@ export EDGE_NODES=2
 # This is where the installation should happen:
 
 export EDGE_CLUSTER="demo"
-export EDGE_CLUSTER_DIR="$HOME/work/nodectl/test/pgedge/cluster/$EDGE_CLUSTER"
+export EDGE_CLUSTER_DIR="pgedge/cluster/$EDGE_CLUSTER"
 
 # These are the properties associated with the setup:
 
 export EDGE_USERNAME="lcusr"
 export EDGE_PASSWORD="password"
 export EDGE_DB="lcdb"
-export EDGE_INST_VERSION=17
+export EDGE_REPUSER=`whoami`
+export EDGE_INST_VERSION=16
 export EDGE_COMPONENT="pg$EDGE_INST_VERSION"
 export EDGE_SPOCK="3.2"
-export EDGE_REPSET="demo-repset"
-
-# These are legacy variables used in older perl tests:
-
-export EDGE_VERSION=pg17
-export EDGE_N1="~/work/nodectl/test/pgedge/cluster/demo/n1"
-export EDGE_N2="~/work/nodectl/test/pgedge/cluster/demo/n2"
-export EDGE_N3="~/work/nodectl/test/pgedge/cluster/demo/n3"
-
-export EDGE_REPUSER=`whoami`
-export EDGE_USERNAME="lcusr"
-export EDGE_PASSWORD=password
-export EDGE_DB=lcdb
-export EDGE_VERSION="pg17"
-export EDGE_INST_VERSION=pg17
-export EDGE_SPOCK=3.2
-export EDGE_CLUSTER=demo
-export EDGE_REPSET=demo-repset
-export EDGE_N1="~/work/nodectl/test/pgedge/cluster/demo/n1"
-export EDGE_N2="~/work/nodectl/test/pgedge/cluster/demo/n2"
-export EDGE_N3="~/work/nodectl/test/pgedge/cluster/demo/n3"
-export EDGE_NODES=3
-export EDGE_TEST="This is a pgedge ENV variable"
-export EDGE_REPSET="demo-repset"
-export EDGE_SCHEMA="public"
-export EDGE_TABLE="foo"
-export EDGE_CHDIR1="/pgedge/cluster/demo/n1"
-export EDGE_CHDIR2="/pgedge/cluster/demo/n2"
-export EDGE_PORT1=6432
-export EDGE_PORT2=6433
-export EDGE_NODE_CHECK="node_create"
-export EDGE_REP_CHECK="repset_create"
-export EDGE_SUB_CHECK="sub_create"
-export EDGE_NODE_DROP="node_drop"
-export EDGE_REP_DROP="repset_drop"
-export EDGE_SUB_DROP="sub_drop"
-
-
-
-
-export EDGE_TEST="This is a test environment variable - use it if/when needed."
+#export EDGE_REPSET="demo-repset"

--- a/test/t/lib/config_old.env
+++ b/test/t/lib/config_old.env
@@ -1,0 +1,65 @@
+# Use this file to set a group of values to environment variables; you can source this file to set all the values at once.
+export EDGE_INSTALL_SCRIPT=install24.py
+export EDGE_REPO=https://pgedge-upstream.s3.amazonaws.com/REPO/$EDGE_INSTALL_SCRIPT
+export EDGE_HOST=127.0.0.1
+
+# Your setup scripts should start at the following port, and iterate through the setup for the number of nodes in 
+# EDGE_NODES.
+
+export EDGE_START_PORT=6432
+export EDGE_NODES=2
+
+# This is where the installation should happen:
+
+export EDGE_CLUSTER="demo"
+export EDGE_CLUSTER_DIR="$HOME/work/nodectl/test/pgedge/cluster/$EDGE_CLUSTER"
+
+# These are the properties associated with the setup:
+
+export EDGE_USERNAME="lcusr"
+export EDGE_PASSWORD="password"
+export EDGE_DB="lcdb"
+export EDGE_INST_VERSION=16
+export EDGE_COMPONENT="pg$EDGE_INST_VERSION"
+export EDGE_SPOCK="3.2"
+export EDGE_REPSET="demo-repset"
+
+# These are legacy variables used in older perl tests:
+
+export EDGE_VERSION=pg16
+export EDGE_N1="~/work/nodectl/test/pgedge/cluster/demo/n1"
+export EDGE_N2="~/work/nodectl/test/pgedge/cluster/demo/n2"
+export EDGE_N3="~/work/nodectl/test/pgedge/cluster/demo/n3"
+
+export EDGE_REPUSER=`whoami`
+export EDGE_USERNAME="lcusr"
+export EDGE_PASSWORD=password
+export EDGE_DB=lcdb
+export EDGE_VERSION="pg16"
+export EDGE_INST_VERSION=pg16
+export EDGE_SPOCK=3.2
+export EDGE_CLUSTER=demo
+export EDGE_REPSET=demo-repset
+export EDGE_N1="~/work/nodectl/test/pgedge/cluster/demo/n1"
+export EDGE_N2="~/work/nodectl/test/pgedge/cluster/demo/n2"
+export EDGE_N3="~/work/nodectl/test/pgedge/cluster/demo/n3"
+export EDGE_NODES=3
+export EDGE_TEST="This is a pgedge ENV variable"
+export EDGE_REPSET="demo-repset"
+export EDGE_SCHEMA="public"
+export EDGE_TABLE="foo"
+export EDGE_CHDIR1="/pgedge/cluster/demo/n1"
+export EDGE_CHDIR2="/pgedge/cluster/demo/n2"
+export EDGE_PORT1=6432
+export EDGE_PORT2=6433
+export EDGE_NODE_CHECK="node_create"
+export EDGE_REP_CHECK="repset_create"
+export EDGE_SUB_CHECK="sub_create"
+export EDGE_NODE_DROP="node_drop"
+export EDGE_REP_DROP="repset_drop"
+export EDGE_SUB_DROP="sub_drop"
+
+
+
+
+export EDGE_TEST="This is a test environment variable - use it if/when needed."


### PR DESCRIPTION
First batch of Test case adjustments to the various 8000 series test cases under repset schedules. These now use the updated set of environment variables in the config.env. The older environment variables are now under config_old.env, that should be sourced incase we need to run any of the other tests that rely on older variables (and will gradually be adjusted to use the updated config.env). The excessive use of nc info commands in each of these files has been reduced since the same information is available from the environment variables. A few test cases (that were previously failing) have been corrected and are now passing.