### PR TITLE
Further updates to the 8000 series test cases to use EDGE_CLI env variable

### DIFF
--- a/test/t/8000_env_install_pgedge_node1.pl
+++ b/test/t/8000_env_install_pgedge_node1.pl
@@ -53,7 +53,7 @@ print("stdout_buf3 = @$stdout_buf3\n");
 chdir("./../../../../");
 # Install PostgreSQL.
 
-my $cmd4 = qq($homedir1/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT});
+my $cmd4 = qq($homedir1/$ENV{EDGE_CLI} install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT} --pg $ENV{EDGE_INST_VERSION});
 print("cmd4 = $cmd4\n");
 my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8001_env_install_pgedge_node2.pl
+++ b/test/t/8001_env_install_pgedge_node2.pl
@@ -54,7 +54,7 @@ print("stdout_buf3 = @$stdout_buf3\n");
 chdir("./../../../../");
 # Install PostgreSQL.
 
-my $cmd4 = qq($homedir2/nodectl install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2);
+my $cmd4 = qq($homedir2/$ENV{EDGE_CLI} install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg $ENV{EDGE_INST_VERSION});
 print("cmd4 = $cmd4\n");
 my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8051_env_create_node1.pl
+++ b/test/t/8051_env_create_node1.pl
@@ -28,7 +28,7 @@ print("The port number is $ENV{EDGE_START_PORT}\n");
 #
 ## Check for n1 node existence
 
-my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
+my $json3 = `$homedir1/$ENV{EDGE_CLI} spock node-list  $ENV{EDGE_DB}`;
    #print("my json3 = $json3");
 my $out3 = decode_json($json3);
   $ENV{EDGE_NODE1_NAME} = $out3->[0]->{"node_name"};
@@ -38,7 +38,7 @@ if($ENV{EDGE_NODE1_NAME} eq "")
 
    {
    
-my $cmd2 = qq($homedir1/nodectl spock node-create n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd2 = qq($homedir1/$ENV{EDGE_CLI} spock node-create n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 

--- a/test/t/8052_env_create_node2.pl
+++ b/test/t/8052_env_create_node2.pl
@@ -33,7 +33,7 @@ print("The port number is $myport2\n");
 #
 ## Check for n2 node existence
 
-my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock node-list  $ENV{EDGE_DB}`;
+my $json3 = `$homedir2/$ENV{EDGE_CLI} spock node-list  $ENV{EDGE_DB}`;
    #print("my json3 = $json3");
 my $out3 = decode_json($json3);
   $ENV{EDGE_NODE2_NAME} = $out3->[0]->{"node_name"};
@@ -44,7 +44,7 @@ if($ENV{EDGE_NODE2_NAME} eq "")
 
    {
    
-my $cmd2 = qq($homedir2/nodectl spock node-create n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd2 = qq($homedir2/$ENV{EDGE_CLI} spock node-create n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 

--- a/test/t/8060_env_delete_false_n1.pl
+++ b/test/t/8060_env_delete_false_n1.pl
@@ -27,7 +27,7 @@ print("The home directory is $homedir1\n");
 
 print("The port number is $ENV{EDGE_START_PORT}\n");
 
-my $cmd5 = qq($homedir1/nodectl spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False );
+my $cmd5 = qq($homedir1/$ENV{EDGE_CLI} spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False );
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -107,7 +107,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n1/pgedge/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -119,7 +119,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($ENV{EDGE_CLUSTER_DIR}/n1/pgedge/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($ENV{EDGE_CLUSTER_DIR}/n1/pgedge/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8061_env_sub_n1n2_delete_false.pl
+++ b/test/t/8061_env_sub_n1n2_delete_false.pl
@@ -30,14 +30,14 @@ print("The port number of node 2 is $myport2\n");
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/$ENV{EDGE_CLI} spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/$ENV{EDGE_CLI} spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8062_env_delete_false_n2.pl
+++ b/test/t/8062_env_delete_false_n2.pl
@@ -30,7 +30,7 @@ print("The home directory is $homedir2\n");
 print("The port number is $myport2\n");
 
 
-my $cmd5 = qq($homedir2/nodectl spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False);
+my $cmd5 = qq($homedir2/$ENV{EDGE_CLI} spock repset-create demo-repset $ENV{EDGE_DB} --replicate_delete=False);
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -107,7 +107,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -119,7 +119,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8065_env_insert_false_n1.pl
+++ b/test/t/8065_env_insert_false_n1.pl
@@ -27,7 +27,7 @@ print("The home directory is $homedir1\n");
 print("The port number is $ENV{EDGE_START_PORT}\n");
 
 
-my $cmd5 = qq($homedir1/nodectl spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/$ENV{EDGE_CLI} spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -105,7 +105,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$homedir1/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$homedir1/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -117,7 +117,7 @@ else
 if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir1/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir1/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8066_env_sub_n1n2_insert_false.pl
+++ b/test/t/8066_env_sub_n1n2_insert_false.pl
@@ -23,14 +23,14 @@ print("The home directory of node 1 is $homedir1\n");
 print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
 
-my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/$ENV{EDGE_CLI} spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/$ENV{EDGE_CLI} spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8067_env_insert_false_n2.pl
+++ b/test/t/8067_env_insert_false_n2.pl
@@ -28,7 +28,7 @@ print("The home directory is $homedir2\n");
 
 print("The port number is $myport2\n");
 
-my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/$ENV{EDGE_CLI} spock repset-create --replicate_insert=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -108,7 +108,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$ENV{EDGE_CLUSTER_DIR}/n2/pgedge/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -120,7 +120,7 @@ else
 if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8068_env_sub_n2n1_insert_false.pl
+++ b/test/t/8068_env_sub_n2n1_insert_false.pl
@@ -27,14 +27,14 @@ print("The port number of node 2 is $myport2\n");
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/$ENV{EDGE_CLI} spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/$ENV{EDGE_CLI} spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8070_env_update_false_n1.pl
+++ b/test/t/8070_env_update_false_n1.pl
@@ -27,7 +27,7 @@ print("The home directory is $homedir1\n");
 
 print("The port number is $ENV{EDGE_START_PORT}\n");
 
-my $cmd5 = qq($homedir1/nodectl spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/$ENV{EDGE_CLI} spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -104,7 +104,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$homedir1/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$homedir1/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -116,7 +116,7 @@ else
 if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir1/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir1/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8071_env_sub_n1n2_update_false.pl
+++ b/test/t/8071_env_sub_n1n2_update_false.pl
@@ -24,14 +24,14 @@ print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 
 # Then, create the subscription on node 1:
 
-my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/$ENV{EDGE_CLI} spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/$ENV{EDGE_CLI} spock sub-add-repset sub_n1n2 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8072_env_update_false_n2.pl
+++ b/test/t/8072_env_update_false_n2.pl
@@ -28,7 +28,7 @@ print("The home directory is $homedir2\n");
 
 print("The port number is $myport2\n");
 
-my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/$ENV{EDGE_CLI} spock repset-create --replicate_update=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -108,7 +108,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$homedir2/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$homedir2/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -120,7 +120,7 @@ else
 if($ENV{EDGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8073_env_sub_n2n1_update_false.pl
+++ b/test/t/8073_env_sub_n2n1_update_false.pl
@@ -25,14 +25,14 @@ print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
-my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/$ENV{EDGE_CLI} spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/$ENV{EDGE_CLI} spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8075_env_truncate_false_n1.pl
+++ b/test/t/8075_env_truncate_false_n1.pl
@@ -28,7 +28,7 @@ print("The port number is $ENV{EDGE_START_PORT}\n");
 
 
 
-my $cmd5 = qq($homedir1/nodectl spock repset-create --replicate_truncate=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir1/$ENV{EDGE_CLI} spock repset-create --replicate_truncate=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -108,7 +108,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$homedir1/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$homedir1/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -120,7 +120,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir1/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir1/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8076_env_sub_n1n2_truncate_false.pl
+++ b/test/t/8076_env_sub_n1n2_truncate_false.pl
@@ -26,14 +26,14 @@ print("The port number on node 1 is $ENV{EDGE_START_PORT}\n");
 # Then, create the subscription on node 1:
 
 
-my $cmd11 = qq($homedir1/nodectl spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/$ENV{EDGE_CLI} spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$myport2 user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir1/nodectl spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir1/$ENV{EDGE_CLI} spock sub-add-repset sub_n1n2 $ENV{EDGE_REPSET} $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8077_env_truncate_false_n2.pl
+++ b/test/t/8077_env_truncate_false_n2.pl
@@ -29,7 +29,7 @@ print("The port number is $myport2\n");
 
 
 
-my $cmd5 = qq($homedir2/nodectl spock repset-create --replicate_truncate=False demo-repset $ENV{EDGE_DB});
+my $cmd5 = qq($homedir2/$ENV{EDGE_CLI} spock repset-create --replicate_truncate=False demo-repset $ENV{EDGE_DB});
 print("cmd5 = $cmd5\n");
 my ($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
 print("stdout_buf5 = @$stdout_buf5\n");
@@ -109,7 +109,7 @@ else
   #
   # Listing repset tables 
   #
-    my $json3 = `$homedir2/nc spock repset-list-tables public $ENV{EDGE_DB}`;
+    my $json3 = `$homedir2/$ENV{EDGE_CLI} spock repset-list-tables public $ENV{EDGE_DB}`;
    print("my json3 = $json3");
    my $out3 = decode_json($json3);
    $ENV{EDGE_SETNAME} = $out3->[0]->{"set_name"};
@@ -121,7 +121,7 @@ else
 if($ENV{EDEGE_SETNAME} eq ""){
   
   
-       my $cmd8 = qq($homedir2/nodectl spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
+       my $cmd8 = qq($homedir2/$ENV{EDGE_CLI} spock repset-add-table demo-repset public.foo $ENV{EDGE_DB});
     
      print("cmd8 = $cmd8\n");
      my($success8, $error_message8, $full_buf8, $stdout_buf8, $stderr_buf8)= IPC::Cmd::run(command => $cmd8, verbose => 0);

--- a/test/t/8078_env_sub_n2n1_truncate_false.pl
+++ b/test/t/8078_env_sub_n2n1_truncate_false.pl
@@ -24,14 +24,14 @@ print("The port number of node 2 is $myport2\n");
 
 # Then, create the subscription on node 1:
 
-my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/$ENV{EDGE_CLI} spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/$ENV{EDGE_CLI} spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8080_env_repset_drop_n1.pl
+++ b/test/t/8080_env_repset_drop_n1.pl
@@ -25,7 +25,7 @@ print("The home directory is $homedir1\n");
 
 print("The port number is $ENV{EDGE_START_PORT}\n");
 
-my $cmd3 = qq($homedir1/nodectl spock repset-drop demo-repset $ENV{EDGE_DB});
+my $cmd3 = qq($homedir1/$ENV{EDGE_CLI} spock repset-drop demo-repset $ENV{EDGE_DB});
 print("cmd3 = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 

--- a/test/t/8081_env_repset_drop_n2.pl
+++ b/test/t/8081_env_repset_drop_n2.pl
@@ -28,7 +28,7 @@ print("The home directory is $homedir2\n");
 print("The port number is $myport2\n");
 
 
-my $cmd3 = qq($homedir2/nodectl spock repset-drop demo-repset $ENV{EDGE_DB});
+my $cmd3 = qq($homedir2/$ENV{EDGE_CLI} spock repset-drop demo-repset $ENV{EDGE_DB});
 print("cmd3 = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 

--- a/test/t/8083_env_sub_drop_n2.pl
+++ b/test/t/8083_env_sub_drop_n2.pl
@@ -24,7 +24,7 @@ print("The port number of node 2 is {$myport2}\n");
 
 # Then, drop the subscription on node 1:
 
-my $cmd11 = qq($homedir2/nodectl spock sub-drop sub_n2n1 $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/$ENV{EDGE_CLI} spock sub-drop sub_n2n1 $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 #print("stdout_buf11 = @$stdout_buf11\n");

--- a/test/t/8086_env_node_drop_n1.pl
+++ b/test/t/8086_env_node_drop_n1.pl
@@ -23,7 +23,7 @@ print("The home directory is $homedir1\n");
 
 # Drop n1 node
 
-my $cmd2 = qq($homedir1/nodectl spock node-drop n1 $ENV{EDGE_DB});
+my $cmd2 = qq($homedir1/$ENV{EDGE_CLI} spock node-drop n1 $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 #print("stdout_buf2 = @$stdout_buf2\n");

--- a/test/t/8087_env_node_drop_n2.pl
+++ b/test/t/8087_env_node_drop_n2.pl
@@ -23,7 +23,7 @@ print("The home directory is $homedir2\n");
 
 # Drop n2 node
 
-my $cmd2 = qq($homedir2/nodectl spock node-drop n2 $ENV{EDGE_DB});
+my $cmd2 = qq($homedir2/$ENV{EDGE_CLI} spock node-drop n2 $ENV{EDGE_DB});
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 #print("stdout_buf2 = @$stdout_buf2\n");

--- a/test/t/lib/config.env
+++ b/test/t/lib/config.env
@@ -10,9 +10,9 @@ export EDGE_START_PORT=6432
 export EDGE_NODES=2
 
 # This is where the installation should happen:
-
+export EDGE_HOME_DIR="pgedge"
 export EDGE_CLUSTER="demo"
-export EDGE_CLUSTER_DIR="pgedge/cluster/$EDGE_CLUSTER"
+export EDGE_CLUSTER_DIR="$EDGE_HOME_DIR/cluster/$EDGE_CLUSTER"
 
 # These are the properties associated with the setup:
 
@@ -24,3 +24,5 @@ export EDGE_INST_VERSION=16
 export EDGE_COMPONENT="pg$EDGE_INST_VERSION"
 export EDGE_SPOCK="3.2"
 #export EDGE_REPSET="demo-repset"
+
+export EDGE_CLI="ctl"


### PR DESCRIPTION
Further updates to the 8000 series test cases so that all the nodectl,nc,ctl commands now use the newly added environment variable EDGE_CLI, currently set to ctl. Additionally, appended the --pg switch to pgedge install command in 8000 and 8001 setup test cases so that they install the PG version as specified in EDGE_INST_VERSION environment variable rather than always defaulting to pg16.