### PR TITLE
nodectl update manager (um) test enhancements

### DIFF
--- a/test/schedule_files/um_schedule
+++ b/test/schedule_files/um_schedule
@@ -10,5 +10,19 @@ t/320_um_install_orafce.pl
 t/323_um_remove_orafce.pl
 t/325_um_install_curl.pl
 t/328_um_remove_curl.pl
+t/329_um_install_cron.pl
+t/332_um_remove_cron.pl
+t/333_um_install_partman.pl
+t/336_um_remove_partman.pl
+t/337_um_install_pldebugger.pl
+t/340_um_remove_pldebugger.pl
+t/341_um_install_plprofiler.pl
+t/344_um_remove_plprofiler.pl
+t/345_um_install_plv8.pl
+t/348_um_remove_plv8.pl
+t/349_um_install_postgis.pl
+t/352_um_remove_postgis.pl
+t/353_um_install_vector.pl
+t/356_um_remove_vector.pl
 t/399_um_breakdown_script.pl
 

--- a/test/t/020_nodectl_install_pgedge.pl
+++ b/test/t/020_nodectl_install_pgedge.pl
@@ -1,27 +1,67 @@
 # 020_nodectl_install_pg.pl
-#
+# This script does the initial setup for um related tests in the 300 series. It checks if the $n1dir already
+# exists, then it assumes both curl and install script has been executed. 
+
+# TODO : The $n1dir check is probably not enough,  we need to check for more objects 
+# At present the 300 series tests are using the same directory structure as used by the 
+# 8000 series tests for n1. This will be changed to use different directory that will be 
+# common for other tests (e.g. service, app, cluster etc)
 
 use strict;
 use warnings;
-
 use File::Which;
-use File::Path;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use File::Copy;
+use lib './t/lib';
+use contains;
+use edge;
 
-my $cmd = system("curl -fsSL https://pgedge-upstream.s3.amazonaws.com/REPO/install24.py > install.py");
-print("cmd = $cmd\n");
+sub handle_error_and_exit {
+    my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf) = @_;
 
-my $cmd2 = system("python install.py");
-print("cmd2 = $cmd2\n");
-
-if (defined($cmd2))
-{
-  exit(0);
+    if (!$success) {
+        print "Error: $error_message\n";
+        print "Full Buffer: @{$full_buf}";
+        #print "Stdout Buffer: @{$stdout_buf}";
+        #print "Stderr Buffer: @{$stderr_buf}";
+        exit(1);
+    }
 }
-else
-{
- exit(1);
+
+my $n1dir = "$ENV{EDGE_CLUSTER_DIR}/n1";
+my $homedir1 = "$n1dir/pgedge";
+
+print "whoami = $ENV{EDGE_REPUSER}\n";
+
+# Check if the directory already exists
+if (-e $homedir1) {
+    print "$homedir1 already installed...\n skipping the download and install and exiting with success\n";
+    exit(0);
 }
 
+# Create a directory to hold a node.
+my $cmd = qq(mkdir -p $n1dir);
+print "Executing cmd = $cmd\n";
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf) = IPC::Cmd::run(command => $cmd, verbose => 0);
+handle_error_and_exit($success, $error_message, $full_buf, $stdout_buf, $stderr_buf);
+
+# Download the install.py file into the directory
+my $cmd2 = qq(curl -fsSL $ENV{EDGE_REPO} > $n1dir/install.py);
+print "Executing cmd2 = $cmd2\n";
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2) = IPC::Cmd::run(command => $cmd2, verbose => 0);
+handle_error_and_exit($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2);
+
+chdir("./$n1dir");
+
+# Run the install.py file.
+my $cmd3 = qq(python install.py);
+print "Executing cmd3 = $cmd3\n";
+my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3) = IPC::Cmd::run(command => $cmd3, verbose => 0);
+handle_error_and_exit($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3);
+
+chdir("./../../../../");
+
+# Success
+exit(0);

--- a/test/t/300_setup_script.pl
+++ b/test/t/300_setup_script.pl
@@ -1,6 +1,6 @@
 #
-# This test sets up a database cluster, adds the user to the pgpass file, and queries the psql command line.
-# The test confirms that the spock extension version noted in the parameter list is installed to confirm success.
+# This test sets up a database cluster, adds the user to the pgpass file, and checks for the installed status
+# This test does a multi step pgV install through the install, init and start
 #
 
 use strict;
@@ -9,91 +9,70 @@ use File::Which;
 use Try::Tiny;
 use IPC::Cmd qw(run);
 use JSON;
+use lib './t/lib';
+use contains;
 
+# Define a subroutine to run a command and handle errors
+sub run_command {
+    my ($cmd) = @_;
+    print ("Executing : $cmd\n");
+    my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf) = IPC::Cmd::run(command => $cmd, verbose => 0);
+
+    if (!defined($success)) {
+        print("Error executing command $cmd: $error_message\n");
+        print("Full Buffer output : @$full_buf\n");
+        exit(1);
+    }
+
+    return ($success, $full_buf, $stdout_buf, $stderr_buf);
+}
 
 # Our parameters are:
 
-my $username = "lcusr";
-my $password = "password";
-my $database = "lcdb";
-my $version = "pg16";
-my $spock = "3.1";
+my $username = $ENV{EDGE_USERNAME};
+my $password = $ENV{EDGE_PASSWORD};
+my $database = $ENV{EDGE_DB};
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $exitcode = 0;
+#my $spock = "3.1";
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
-
-#
-# First, we use nodectl to install pgEdge.
-# 
-
-my $cmd = qq(./nodectl install pgedge $version -U $username -P $password -d $database);
-print("cmd = $cmd\n");
-my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
-
-print("cmd = $cmd\n");
-print("stdout_buf = @$stdout_buf\n");
-
-# Then, we retrieve the port number from nodectl in json form... this is to catch cases where more than one copy of 
-# Postgres is running.
-#
-my $json = `./nc --json info $version`;
-print("my json = $json");
-my $out = decode_json($json);
-
-my $port = $out->[0]->{"port"};
-
-print("The port number is = {$port}\n");
-
-
-#
-# Then, we add an entry to the ~/.pgpass file for the user so we can connect with psql.
-#
-
-my $cmd3 = qq(echo "*:*:*:$username:password" >> ~/.pgpass);
-my($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
-
-print("We'll need to authenticate to use psql, so we're adding the password to the .pgpass file = {@$stderr_buf3}\n");
-
-#
-# We need to get the location of the home directory so we can run psql; store it in $homedir.
-#
-
-my $out2 = decode_json(`./nc --json info`);
-my $homedir = $out2->[0]->{"home"};
-print("The home directory is = {$homedir}\n");
-
-#
-# Connect with psql, and confirm that I'm in the correct database.
-#
-
-my $cmd5 = qq($homedir/pg16/bin/psql -t -h 127.0.0.1 -p $port -U $username -d $database -c "select * from current_database()");
-print("cmd5 = $cmd5\n");
-my($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
-
-print("success5 = $success5\n");
-print("full_buf5 = @$full_buf5\n");
-print("stdout_buf5 = @$stdout_buf5\n");
-
-#
-# Then, we use the port number from the previous section to connect to psql and test for the existence of the spock extension.
-#
-
-my $cmd6 = qq($homedir/pg16/bin/psql -t -h 127.0.0.1 -p $port -U $username -d $database -c "SELECT installed_version FROM pg_available_extensions WHERE name='spock'");
-print("cmd6 = $cmd6\n");
-my($success6, $error_message6, $full_buf6, $stdout_buf6, $stderr_buf6)= IPC::Cmd::run(command => $cmd6, verbose => 0);
-
-print("success6 = $success6\n");
-print("full_buf6 = @$full_buf6\n");
-print("stdout_buf6 = @$stdout_buf6\n");
-
-if ($full_buf6 = $spock)
-{
-    exit(0);
-}
-else
-{
+# Doing a multi step pgV install on a custom port 
+# um install pgV
+my ($success, $full_buf, $stdout_buf, $stderr_buf) = run_command(qq($homedir/$cli um install $pgversion));
+# Check if 'already installed' is present in stdout_buf
+if (grep { /already installed/i } @$stdout_buf) {
+    print("$pgversion Already installed, Exiting. Full Buffer (Install): @$stdout_buf\n");
     exit(1);
 }
 
+# initialise cluster (initdb) through init pgV specifying a custom port
+run_command(qq(pgePasswd=$password $homedir/$cli init $pgversion --port=$port));
+
+# Starting pgV server
+run_command(qq($homedir/$cli start $pgversion));
+
+print("Adding credentials to .pgpass file");
+run_command(qq(echo "*:*:*:$username:$password" >> ~/.pgpass && chmod 600 ~/.pgpass));
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $pgversion)))
+    {
+        print("$pgversion not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);

--- a/test/t/305_um_list.pl
+++ b/test/t/305_um_list.pl
@@ -10,61 +10,29 @@ use JSON;
 use lib './t/lib';
 use contains;
 
-# Our parameters are:
+my $homedir = "$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $pgversion = "$ENV{EDGE_COMPONENT}";
+my $cli = "$ENV{EDGE_CLI}";
 
-our $repuser = `whoami`;
-our $username = "$ENV{EDGE_USERNAME}";
-our $password = "$ENV{EDGE_PASSWORD}";
-our $database = "$ENV{EDGE_DB}";
-our $inst_version = "$ENV{EDGE_INST_VERSION}";
-our $cmd_version = "$ENV{EDGE_COMPONENT}";
-our $spock = "$ENV{EDGE_SPOCK}";
-our $cluster = "$ENV{EDGE_CLUSTER}";
-our $repset = "$ENV{EDGE_REPSET}";
-our $n1 = "$ENV{EDGE_N1}";
-our $n2 = "$ENV{EDGE_N2}";
-our $n3 = "$ENV{EDGE_N3}";
-
-#
-# Move into the pgedge directory
-
-chdir ("./pgedge");
-
-# Node 1:
-# We can retrieve the home directory from nodectl in json form...
-my $json = `$n1/pgedge/nc --json info`;
-#print("my json = $json");
-my $out = decode_json($json);
-my $homedir = $out->[0]->{"home"};
 print("The home directory is {$homedir}\n");
 
-# We can retrieve the port number from nodectl in json form...
-my $json2 = `$n1/pgedge/nc --json info $cmd_version`;
-#print("my json = $json2");
-my $out2 = decode_json($json2);
-my $port = $out2->[0]->{"port"};
-print("The port number is {$port}\n");
+# First, we call the ./$cli um list command:
 
-#
-# Move into the pgedge directory
-
-chdir ("./pgedge");
-
-# First, we call the ./nc um list command:
-
-my $cmd = qq($homedir/nc um list);
+my $cmd = qq($homedir/$cli um list);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+print("stdout : @$full_buf \n");
 
-if(!(contains(@$stdout_buf[0], "pg")))
-
+if(!(is_umlist_component_installed($stdout_buf, "$pgversion")))
 {
+    print("$pgversion not installed. Exiting with code 1\n");
     exit(1);
 }
 
-# ERROR CASE: We are misspelling the ./nc mu list command:
 
-my $cmd1 = qq($homedir/nc mu list);
+# ERROR CASE: We are misspelling the ./$cli mu list command:
+
+my $cmd1 = qq($homedir/$cli mu list);
 print("cmd1 = $cmd1\n");
 my ($success1, $error_message1, $full_buf1, $stdout_buf1, $stderr_buf1)= IPC::Cmd::run(command => $cmd1, verbose => 0);
 
@@ -73,9 +41,9 @@ if(!(contains(@$full_buf1[0], "Invalid")))
     exit(1);
 }
 
-# We are exercising the ./nc um update command. 
+# We are exercising the .$cli um update command. 
 
-my $cmd2 = qq($homedir/nc um update);
+my $cmd2 = qq($homedir/$cli um update);
 print("cmd2 = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 

--- a/test/t/306_nc_um_list.pl
+++ b/test/t/306_nc_um_list.pl
@@ -6,18 +6,44 @@ use strict;
 use warnings;
 
 use File::Which;
-#use PostgreSQL::Test::Cluster;
-#use PostgreSQL::Test::Utils;
-#use Test::More tests => 3;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
 
+
+my $homedir = "$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $pgversion = "$ENV{EDGE_COMPONENT}";
+my $cli = "$ENV{EDGE_CLI}";
+
+
+my $cmd = qq($homedir/$cli um list);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success)) 
+{
+    if(!(is_umlist_component_installed($stdout_buf, "$pgversion")))
+    {
+        print("$pgversion not installed. Exiting with code 1\n");
+        exit(1);
+    }
+} 
+else
+{
+    print("$cmd not executed successfully. stderr buffer :  @$full_buf\n");
+    exit(1);
+} 
+
+exit(0);
+
+=pod
 #
 # Move into the pgedge directory
 #
 
-chdir ("./pgedge");
+#chdir ("./pgedge");
 
 # 
 # We are now exercising the ./nc um list variation; a successful run returns 1.
@@ -43,3 +69,4 @@ else
 {
     exit(1);
 }
+=cut

--- a/test/t/307_nc_mu_list.pl
+++ b/test/t/307_nc_mu_list.pl
@@ -11,33 +11,20 @@ use File::Which;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
+
+my $homedir = "$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = "$ENV{EDGE_CLI}";
 
 
-#
-# Move into the pgedge directory
-#
+my $cmd1 = qq($homedir/$cli mu list);
+print("cmd1 = $cmd1\n");
+my ($success1, $error_message1, $full_buf1, $stdout_buf1, $stderr_buf1)= IPC::Cmd::run(command => $cmd1, verbose => 0);
 
-chdir ("./pgedge");
-
-#
-# We are now exercising the error message for a bad command entry; a successful run returns 0.
-#
-
-my $cmd3 = qq(./nc mu list);
-print("cmd3 = $cmd3\n");
-my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
-
-print("success3 = $success3\n");
-print("error_message3 = $error_message3\n");
-print("full_buf3 = @$full_buf3\n");
-print("stdout_buf3 = @$stdout_buf3\n");
-print("stderr_buf3 = @$stderr_buf3\n");
-
-if (defined($error_message3))
-{
-    exit(0);
-}
-else
+if(!(contains(@$full_buf1[0], "Invalid")))
 {
     exit(1);
 }
+
+exit(0);

--- a/test/t/310_um_update.pl
+++ b/test/t/310_um_update.pl
@@ -5,35 +5,24 @@ use strict;
 use warnings;
 
 use File::Which;
-#use PostgreSQL::Test::Cluster;
-#use PostgreSQL::Test::Utils;
-#use Test::More tests => 1;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# First, we find the list of available components with ./nc um update
-# 
+my $homedir = "$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = "$ENV{EDGE_CLI}";
 
-my $cmd = qq(./nc um update);
-print("cmd = $cmd\n");
-my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+my $cmd2 = qq($homedir/$cli um update);
+print("cmd2 = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 
-print("stdout_buf = @$stdout_buf\n");
-
-my $version = $success;
-
-if (defined($version))
+if((contains(@$stdout_buf2[0], "Retrieving")))
 {
     exit(0);
 }
-else
 {
     exit(1);
 }

--- a/test/t/317_um_remove_hypopg.pl
+++ b/test/t/317_um_remove_hypopg.pl
@@ -6,40 +6,47 @@ use strict;
 use warnings;
 
 use File::Which;
-#use PostgreSQL::Test::Cluster;
-#use PostgreSQL::Test::Utils;
-#use Test::More tests => 3;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# In this stanza, we'll remove hypopg with the command: ./nc um remove hypopg-pg16
-#
+# Our parameters are:
 
-my $cmd = qq(./nc um remove hypopg-pg16);
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "hypopg-$pgversion";
+my $exitcode = 1;
+
+my $cmd = qq($homedir/$cli um remove $component);
 print("cmd = $cmd\n");
-my($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
 print("success = $success\n");
-print("error_message = $error_message\n");
-print("full_buf = @$full_buf\n");
 print("stdout_buf = @$stdout_buf\n");
-print("stderr_buf = @$stderr_buf\n");
 
-my $value = $success;
-
-if (defined($value))
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
 {
-    exit(0);
-}
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
 else
 {
-    exit(1);
-}
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
 
+exit($exitcode);

--- a/test/t/320_um_install_orafce.pl
+++ b/test/t/320_um_install_orafce.pl
@@ -2,90 +2,51 @@
 # ./nc um install orafce-pg16
 #
 
+
 use strict;
 use warnings;
-
 use File::Which;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
+
 
 # Our parameters are:
 
-my $username = "lcusr";
-my $password = "password";
-my $database = "lcdb";
-my $version = "pg16";
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "orafce-$pgversion";
+my $exitcode = 0;  
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# First, we install orafce with the command ./nc um install orafce
-# 
-
-my $cmd = qq(./nc um install orafce-pg16);
+my $cmd = qq($homedir/$cli um install $component);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
-#
-# Success is a boolean value; 0 means true, any other value is false. 
-#
-print("success = $success");
-print("error_message = $error_message");
+print("success = $success\n");
 print("stdout_buf = @$stdout_buf\n");
 
-#
-# Then, we retrieve the home directory...
-#
-my $json = `./nc --json info`;
-print("my json = $json");
-my $out = decode_json($json);
-my $homedir = $out->[0]->{"home"};
-
-print("The home directory is {$homedir}\n");
-
-
-#
-# Then, we retrieve the port number from nodectl in json form...
-#
-my $json2 = `./nc --json info pg16`;
-print("my json = $json2");
-my $out2 = decode_json($json2);
-my $port = $out2->[0]->{"port"};
-
-print("The port number is {$port}\n");
-
-#
-# Then, we use the port number from the previous section to connect to psql and test for the existence of the extension.
-#
-
-my $cmd5 = qq($homedir/$version/bin/psql -t -h 127.0.0.1 -p $port -d $database -c "SELECT * FROM pg_available_extensions WHERE name='orafce'");
-print("cmd5 = $cmd5\n");
-my($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
-
-print("success5 = $success5\n");
-print("stdout_buf5 = @$stdout_buf5\n");
-
-#
-# Test
-#
-
-print("success = $success\n");
-print("stdout_buf = @$full_buf\n");
-print("If the word CREATE is in @$full_buf we've installed orafce!\n");
-
-my $substring = "CREATE";
-if(index($stdout_buf, $substring) == -1)
-
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
 {
-    exit(0);
-}
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
 else
 {
-    exit(1);
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
 }
 
+exit($exitcode);
 

--- a/test/t/323_um_remove_orafce.pl
+++ b/test/t/323_um_remove_orafce.pl
@@ -6,40 +6,50 @@ use strict;
 use warnings;
 
 use File::Which;
-#use PostgreSQL::Test::Cluster;
-#use PostgreSQL::Test::Utils;
-#use Test::More tests => 3;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# In this stanza, we'll remove orafce with the command: ./nc um remove orafce-pg16
-#
+# Our parameters are:
 
-my $cmd = qq(./nc um remove orafce-pg16);
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "orafce-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
 print("cmd = $cmd\n");
-my($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
 print("success = $success\n");
-print("error_message = $error_message\n");
-print("full_buf = @$full_buf\n");
 print("stdout_buf = @$stdout_buf\n");
-print("stderr_buf = @$stderr_buf\n");
 
-my $value = $success;
-
-if (defined($value))
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
 {
-    exit(0);
-}
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
 else
 {
-    exit(1);
-}
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+
 

--- a/test/t/325_um_install_curl.pl
+++ b/test/t/325_um_install_curl.pl
@@ -1,90 +1,52 @@
 # This test case installs curl with the commands:
-# ./nc um install curl -pg16
+# ./nc um install curl-pgV
 #
+
 
 use strict;
 use warnings;
-
 use File::Which;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
+
 
 # Our parameters are:
 
-my $username = "lcusr";
-my $password = "password";
-my $database = "lcdb";
-my $version = "pg16";
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "curl-$pgversion";
+my $exitcode = 0;  
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# First, we install curl with the command ./nc um install curl
-# 
-
-my $cmd = qq(./nc um install curl);
+my $cmd = qq($homedir/$cli um install $component);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
-#
-# Success is a boolean value; 0 means true, any other value is false. 
-#
-print("success = $success");
-print("error_message = $error_message");
+print("success = $success\n");
 print("stdout_buf = @$stdout_buf\n");
 
-#
-# Then, we retrieve the home directory...
-#
-my $json = `./nc --json info`;
-print("my json = $json");
-my $out = decode_json($json);
-my $homedir = $out->[0]->{"home"};
-
-print("The home directory is {$homedir}\n");
-
-
-#
-# Then, we retrieve the port number from nodectl in json form...
-#
-my $json2 = `./nc --json info pg16`;
-print("my json = $json2");
-my $out2 = decode_json($json2);
-my $port = $out2->[0]->{"port"};
-
-print("The port number is {$port}\n");
-
-#
-# Then, we use the port number from the previous section to connect to psql and test for the existence of the extension.
-#
-
-my $cmd5 = qq($homedir/$version/bin/psql -t -h 127.0.0.1 -p $port -d $database -c "SELECT * FROM pg_available_extensions WHERE name='pg_curl'");
-print("cmd5 = $cmd5\n");
-my($success5, $error_message5, $full_buf5, $stdout_buf5, $stderr_buf5)= IPC::Cmd::run(command => $cmd5, verbose => 0);
-
-print("success5 = $success5\n");
-print("stdout_buf5 = @$stdout_buf5\n");
-
-#
-# Test
-#
-
-print("success = $success\n");
-print("stdout_buf = @$full_buf\n");
-print("If the word CREATE is in @$full_buf we've installed curl!\n");
-
-my $substring = "CREATE";
-if(index($stdout_buf, $substring) == -1)
-
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
 {
-    exit(0);
-}
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
 else
 {
-    exit(1);
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
 }
+
+exit($exitcode);
 

--- a/test/t/328_um_remove_curl.pl
+++ b/test/t/328_um_remove_curl.pl
@@ -1,45 +1,55 @@
 # This test case removes curl with the command:
-# ./nc um remove curl-pg16
+# ./nc um remove curl-pgV
 #
+
 
 use strict;
 use warnings;
 
 use File::Which;
-#use PostgreSQL::Test::Cluster;
-#use PostgreSQL::Test::Utils;
-#use Test::More tests => 3;
 use IPC::Cmd qw(run);
 use Try::Tiny;
 use JSON;
+use lib './t/lib';
+use contains;
 
-#
-# Move into the pgedge directory.
-#
- chdir("./pgedge");
 
-#
-# In this stanza, we'll remove curl with the command: ./nc um remove curl-pg16
-#
+# Our parameters are:
 
-my $cmd = qq(./nc um remove curl-pg16);
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "curl-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
 print("cmd = $cmd\n");
-my($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
 print("success = $success\n");
-print("error_message = $error_message\n");
-print("full_buf = @$full_buf\n");
 print("stdout_buf = @$stdout_buf\n");
-print("stderr_buf = @$stderr_buf\n");
 
-my $value = $success;
-
-if (defined($value))
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
 {
-    exit(0);
-}
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
 else
 {
-    exit(1);
-}
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
 

--- a/test/t/329_um_install_cron.pl
+++ b/test/t/329_um_install_cron.pl
@@ -1,0 +1,52 @@
+# This test case installs cron with the commands:
+# ./nc um install cron-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "cron-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);
+

--- a/test/t/332_um_remove_cron.pl
+++ b/test/t/332_um_remove_cron.pl
@@ -1,0 +1,55 @@
+# This test case removes cron with the command:
+# ./nc um remove cron-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "cron-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/333_um_install_partman.pl
+++ b/test/t/333_um_install_partman.pl
@@ -1,0 +1,51 @@
+# This test case installs partman with the commands:
+# ./nc um install partman-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "partman-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);

--- a/test/t/336_um_remove_partman.pl
+++ b/test/t/336_um_remove_partman.pl
@@ -1,0 +1,54 @@
+# This test case removes partman with the command:
+# ./nc um remove partman-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "partman-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);

--- a/test/t/337_um_install_pldebugger.pl
+++ b/test/t/337_um_install_pldebugger.pl
@@ -1,0 +1,51 @@
+# This test case installs pldebugger with the commands:
+# ./nc um install pldebugger-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "pldebugger-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);

--- a/test/t/340_um_remove_pldebugger.pl
+++ b/test/t/340_um_remove_pldebugger.pl
@@ -1,0 +1,55 @@
+# This test case removes pldebugger with the command:
+# ./nc um remove pldebugger-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "pldebugger-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/341_um_install_plprofiler.pl
+++ b/test/t/341_um_install_plprofiler.pl
@@ -1,0 +1,52 @@
+# This test case installs plprofiler with the commands:
+# ./nc um install plprofiler-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "plprofiler-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);
+

--- a/test/t/344_um_remove_plprofiler.pl
+++ b/test/t/344_um_remove_plprofiler.pl
@@ -1,0 +1,55 @@
+# This test case removes plprofiler with the command:
+# ./nc um remove plprofiler-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "plprofiler-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/345_um_install_plv8.pl
+++ b/test/t/345_um_install_plv8.pl
@@ -1,0 +1,51 @@
+# This test case installs plv8 with the commands:
+# ./nc um install plv8-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "plv8-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);

--- a/test/t/348_um_remove_plv8.pl
+++ b/test/t/348_um_remove_plv8.pl
@@ -1,0 +1,55 @@
+# This test case removes plv8 with the command:
+# ./nc um remove plv8-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "plv8-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/349_um_install_postgis.pl
+++ b/test/t/349_um_install_postgis.pl
@@ -1,0 +1,52 @@
+# This test case installs postgis with the commands:
+# ./nc um install postgis-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "postgis-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);
+

--- a/test/t/352_um_remove_postgis.pl
+++ b/test/t/352_um_remove_postgis.pl
@@ -1,0 +1,55 @@
+# This test case removes postgis with the command:
+# ./nc um remove postgis-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "postgis-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/353_um_install_vector.pl
+++ b/test/t/353_um_install_vector.pl
@@ -1,0 +1,52 @@
+# This test case installs vector with the commands:
+# ./nc um install vector-pgV
+#
+
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "vector-$pgversion";
+my $exitcode = 0;  
+
+
+my $cmd = qq($homedir/$cli um install $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (!(is_umlist_component_installed($stdout_buf2, $component)))
+    {
+        print("$component not installed. Setting exit code to 1\n");
+        $exitcode = 1;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. Full buffer: @$full_buf2\n");
+    $exitcode = 1;
+}
+
+exit($exitcode);
+

--- a/test/t/356_um_remove_vector.pl
+++ b/test/t/356_um_remove_vector.pl
@@ -1,0 +1,55 @@
+# This test case removes vector with the command:
+# ./nc um remove vector-pgV
+#
+
+
+use strict;
+use warnings;
+
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+
+
+# Our parameters are:
+
+
+my $port = $ENV{EDGE_START_PORT};
+my $pgversion = $ENV{EDGE_COMPONENT};
+my $homedir="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $cli = $ENV{EDGE_CLI};
+my $component = "vector-$pgversion";
+my $exitcode = 0;
+
+my $cmd = qq($homedir/$cli um remove $component);
+print("cmd = $cmd\n");
+my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
+
+print("success = $success\n");
+print("stdout_buf = @$stdout_buf\n");
+
+my $cmd2 = qq($homedir/$cli um list);
+print("cmd = $cmd2\n");
+my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
+#print("stdout : @$full_buf \n");
+if (defined($success2)) 
+{
+    if (is_umlist_component_installed($stdout_buf2, $component)) {
+        print("$component is still Installed. Failure\n");
+        $exitcode = 1;
+    } else {
+        print("$component uninstalled successfully\n");
+        $exitcode = 0;
+    }
+} 
+else
+{
+    print("$cmd2 not executed successfully. full buffer :  @$full_buf\n");
+    $exitcode = 1;
+} 
+
+exit($exitcode);
+

--- a/test/t/8063_env_sub_n2n1_delete_false.pl
+++ b/test/t/8063_env_sub_n2n1_delete_false.pl
@@ -27,14 +27,14 @@ print("The port number of node 2 is $myport2\n");
 # Then, create the subscription on node 2:
 
 
-my $cmd11 = qq($homedir2/nodectl spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+my $cmd11 = qq($homedir2/$ENV{EDGE_CLI} spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$ENV{EDGE_START_PORT} user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 print("stdout_buf11 = @$stdout_buf11\n");
 
  # Adding repset (demo-repset) to the subscripton sub_n1n2
 
-    my $cmd4 = qq($homedir2/nodectl spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
+    my $cmd4 = qq($homedir2/$ENV{EDGE_CLI} spock sub-add-repset sub_n2n1 demo-repset $ENV{EDGE_DB});
     print("cmd4 = $cmd4\n");    
     my ($success4, $error_message4, $full_buf4, $stdout_buf4, $stderr_buf4)= IPC::Cmd::run(command => $cmd4, verbose => 0);
 

--- a/test/t/8082_env_sub_drop_n1.pl
+++ b/test/t/8082_env_sub_drop_n1.pl
@@ -24,7 +24,7 @@ print("The port number on node 1 is {$ENV{EDGE_START_PORT}}\n");
 
 # Then, drop the subscription on node 1:
 
-my $cmd11 = qq($homedir1/nodectl spock sub-drop sub_n1n2 $ENV{EDGE_DB});
+my $cmd11 = qq($homedir1/$ENV{EDGE_CLI} spock sub-drop sub_n1n2 $ENV{EDGE_DB});
 print("cmd11 = $cmd11\n");
 my($success11, $error_message11, $full_buf11, $stdout_buf11, $stderr_buf11)= IPC::Cmd::run(command => $cmd11, verbose => 0);
 #print("stdout_buf11 = @$stdout_buf11\n");

--- a/test/t/lib/contains.pm
+++ b/test/t/lib/contains.pm
@@ -58,6 +58,26 @@ sub contains
     }
 }
 
+# This function takes an input of the standard output buffer of the ctl um list command 
+# and traverses through each row to find both the component name (passed as paraemter) and  
+# the word Installed in the same line. Returns 1 if its able to find both (indicating the component is installed)
+# otherwise 0.
+
+sub is_umlist_component_installed {
+    my ($stdout_ref, $component) = @_;
+
+    for my $line (split /\r?\n/, join("\n", @$stdout_ref)) {
+        #print "Line : $line\n"; # Print each line with line number
+
+        if ($line =~ /\b$component\b/i && $line =~ /\bInstalled\b/) {
+            print("$component is listed as installed.\n");
+            return 1; # True, both component and "Installed" found in the same line
+        }
+    }
+    print("$component is NOT Installed\n");
+    return 0; # False, either component or "Installed" not found in the same line
+}
+
 # This 1 at the end is required, even though it looks like an accident :)
 1;
 


### PR DESCRIPTION
Several enhancements to the tests in um_schedule:
- Update manager (um) tests in the 300 series enhanced with newer environment variables.
- 020 setup script now utilizes a previously cached download, avoiding redundant downloads.
- 0300 setup script changed to use multi-stage install, init, and start commands for pgV.
- Added function in contains.pm to parse um list output since --json option is not available.
- Updated all um tests to use the new um list parsing function.
- Adjusted 399 breakdown script to remove pgV install and prevent rm -rf.
- Implemented various enhancements and validation checks to ensure all tests pass.
- Added new tests for um install, list, and remove for cron, partman, pldebugger, plprofiler, plv8, postgis, and vector extensions.

