### PR TITLE
pgedge installation with slowdisk issue

### DIFF
--- a/src/pgXX/run-pgctl.py
+++ b/src/pgXX/run-pgctl.py
@@ -28,5 +28,6 @@ logfile = util.get_column("logdir", pgver) + os.sep + "postgres.log"
 
 util.read_env_file(pgver)
 
-cmd = pg_ctl + ' start -s -w -D "' + datadir + '" ' + '-l "' + logfile + '"'
+# Wait enough before exit
+cmd = pg_ctl + ' start -s -w -t 600 -D "' + datadir + '" ' + '-l "' + logfile + '"'
 util.system(cmd)

--- a/src/pgXX/start-pgXX.py
+++ b/src/pgXX/start-pgXX.py
@@ -37,8 +37,7 @@ cmd = sys.executable + " " + homedir + os.sep + "run-pgctl.py"
 if autostart == "on":
     startup.start_linux("pg" + pgver[2:4])
 else:
-    startCmd = cmd + " &"
-    subprocess.Popen(startCmd, preexec_fn=os.setpgrp(), close_fds=True, shell=True)
+    subprocess.run(cmd, preexec_fn=os.setpgrp(), close_fds=True, shell=True)
 
 isYes = os.getenv("isYes", "False")
 pgName = os.getenv("pgName", "")


### PR DESCRIPTION
It is observed that installation on AWS fail with slow disk via CLI. It seems
to be a bug that caused the issue. Replacing `subprocess.Popen` with
`subprocess.run` as it is asynchronous in nature and do not wait for the
process to finish. Also added more timeout value for `pg_ctl` command as it's
default wait time is 60 seconds only (Jira CUS-30)
