### PR TITLE
Disable auto-ddl gucs during mtree creation

### DIFF
--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -197,6 +197,8 @@ def get_cols(p_con, p_schema, p_table):
     WHERE
         table_schema = %s
         AND table_name = %s
+    ORDER BY
+        ordinal_position;
     """
 
     try:

--- a/cli/scripts/ace_mtree.py
+++ b/cli/scripts/ace_mtree.py
@@ -2633,6 +2633,10 @@ def _mtree_init(conn) -> None:
     """
     cur = conn.cursor()
 
+    # We need to disable DDL GUCs here as well since we're creating the
+    # metadata table
+    cur.execute(sql.SQL(DISABLE_DDL_GUCS))
+
     # We need pgcrypto for sha256
     cur.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS pgcrypto;"))
 
@@ -2642,7 +2646,7 @@ def _mtree_init(conn) -> None:
     cur.execute(sql.SQL(CREATE_XOR_FUNCTION))
 
     # Metadata table where we keep track of tables, their approx. row counts,
-    # and when the tree was last updated.
+    # and when the merkle trees were last updated.
     cur.execute(sql.SQL("DROP TABLE IF EXISTS ace_mtree_metadata"))
     cur.execute(sql.SQL(CREATE_METADATA_TABLE))
 

--- a/cli/scripts/ace_mtree.py
+++ b/cli/scripts/ace_mtree.py
@@ -28,6 +28,7 @@ from ace_sql import (
     CREATE_BULK_TRIGGER_FUNCTION,
     CREATE_METADATA_TABLE,
     CREATE_XOR_FUNCTION,
+    DISABLE_DDL_GUCS,
     DROP_BULK_TRIGGER_FUNCTION,
     DROP_METADATA_TABLE,
     DROP_XOR_FUNCTION,
@@ -276,6 +277,8 @@ def create_mtree_objects(
     with conn.cursor() as cur:
         if recreate_objects:
             _mtree_init(conn)
+
+        cur.execute(sql.SQL(DISABLE_DDL_GUCS))
 
         cur.execute(
             sql.SQL("DROP TABLE IF EXISTS {mtree_table}").format(

--- a/cli/scripts/ace_sql.py
+++ b/cli/scripts/ace_sql.py
@@ -61,6 +61,12 @@ CREATE_COMPOSITE_MTREE_TABLE = """
     WHERE node_level = 0;
 """
 
+DISABLE_DDL_GUCS = """
+    SET spock.enable_ddl_replication = off;
+    SET spock.include_ddl_repset = off;
+    SET spock.allow_ddl_from_functions = off;
+"""
+
 CREATE_GENERIC_TRIGGER = """
     DROP TRIGGER IF EXISTS {trigger}_insert_stmt ON {schema}.{table};
     DROP TRIGGER IF EXISTS {trigger}_update_stmt ON {schema}.{table};


### PR DESCRIPTION
Merkle trees, along with their metadata, are stored in a table after they get built for a target relation. During comparison (`mtree table-diff`), this table (`ace_mtree_<schema>_<table>`) is used for tree traversal and identifying diffs. Therefore, these tables should *not* be replicated.
 
However, when the following GUCs are enabled (which they are, by default, in certain installations):
```
spock.enable_ddl_replication = on;
spock.include_ddl_repset = on;
spock.allow_ddl_from_functions = on;
```
The metadata tables get added to the default repset, and they start replicating. Hence, to prevent this from happening, these GUCs are disabled just before the Merkle tree objects are created.

This PR also fixes a column ordering bug during table-diff.
